### PR TITLE
feat(ui-kit): custom color schemes + lint-rule additions & design-token migration

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -2,6 +2,7 @@ const { FlatCompat } = require('@eslint/eslintrc');
 const nxEslintPlugin = require('@nx/eslint-plugin');
 const js = require('@eslint/js');
 const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
+const rt = require('./tools/lint-rules/index.cjs');
 
 const compat = new FlatCompat({
     baseDirectory: __dirname,
@@ -174,6 +175,7 @@ module.exports = [
     ...compat.config({ extends: ['plugin:@nx/angular-template'] }).map((config) => ({
         ...config,
         files: ['**/*.html'],
+        plugins: { ...(config.plugins || {}), rt },
         rules: {
             '@angular-eslint/template/banana-in-box': ['error'],
             '@angular-eslint/template/cyclomatic-complexity': [
@@ -188,6 +190,10 @@ module.exports = [
              */
             '@angular-eslint/template/no-call-expression': 'off',
             '@angular-eslint/template/no-negated-async': 'error',
+
+            // Custom BEM-only rule. Warn while templates still use
+            // raw class= / [class.x] for the Material bridge; bump to error after migration.
+            'rt/require-bem-directives': 'warn',
         },
     })),
     ...compat.config({ env: { jest: true } }).map((config) => ({
@@ -201,6 +207,26 @@ module.exports = [
         files: ['**/bem/*.directive.ts'],
         rules: {
             '@angular-eslint/prefer-inject': 'off',
+        },
+    },
+    {
+        // Custom workspace rules (rt-tools conventions).
+        // The TS parser/projectService is contributed by the @nx/typescript compat block above.
+        files: ['**/*.ts'],
+        ignores: ['**/*.spec.ts', '**/*.spec.js'],
+        plugins: { rt },
+        rules: {
+            // 0 violations in the current codebase → safe at error.
+            'rt/require-source-suffix-for-subjects': 'error',
+            // 0 violations after adding take(1) to the idb-storage / aside subscriptions and
+            // disabling the rule on the non-RxJS Redux DevTools .subscribe(). Enforced at error.
+            'rt/require-take-until-destroyed': 'error',
+            // 0 violations after fixing 13 components that used rtMod without importing
+            // ModDirective (modifiers were silently dropped at runtime). Enforced at error.
+            'rt/require-mod-directive-import': 'error',
+            // rt-tools uses string-literal `host: { class: '...' }` (not a BEM_BLOCK const) and
+            // only on some components — warn to surface, not break, until a convention decision.
+            'rt/require-host-bem-block': 'warn',
         },
     },
     {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
         "stylelint": "^16.26.1",
         "stylelint-config-idiomatic-order": "^10.0.0",
         "stylelint-config-standard": "^39.0.1",
+        "stylelint-config-standard-scss": "^17.0.0",
         "stylelint-prettier": "^5.0.3",
         "stylelint-scss": "^6.12.1",
         "ts-jest": "^29.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
             stylelint-config-standard:
                 specifier: ^39.0.1
                 version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+            stylelint-config-standard-scss:
+                specifier: ^17.0.0
+                version: 17.0.0(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3))
             stylelint-prettier:
                 specifier: ^5.0.3
                 version: 5.0.3(prettier@3.8.1)(stylelint@16.26.1(typescript@5.9.3))
@@ -1526,11 +1529,24 @@ packages:
         resolution: { integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw== }
         engines: { node: '>=12' }
 
+    '@csstools/css-calc@3.2.1':
+        resolution: { integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg== }
+        engines: { node: '>=20.19.0' }
+        peerDependencies:
+            '@csstools/css-parser-algorithms': ^4.0.0
+            '@csstools/css-tokenizer': ^4.0.0
+
     '@csstools/css-parser-algorithms@3.0.5':
         resolution: { integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ== }
         engines: { node: '>=18' }
         peerDependencies:
             '@csstools/css-tokenizer': ^3.0.4
+
+    '@csstools/css-parser-algorithms@4.0.0':
+        resolution: { integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w== }
+        engines: { node: '>=20.19.0' }
+        peerDependencies:
+            '@csstools/css-tokenizer': ^4.0.0
 
     '@csstools/css-syntax-patches-for-csstree@1.1.2':
         resolution: { integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA== }
@@ -1540,9 +1556,21 @@ packages:
             css-tree:
                 optional: true
 
+    '@csstools/css-syntax-patches-for-csstree@1.1.5':
+        resolution: { integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A== }
+        peerDependencies:
+            css-tree: ^3.2.1
+        peerDependenciesMeta:
+            css-tree:
+                optional: true
+
     '@csstools/css-tokenizer@3.0.4':
         resolution: { integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw== }
         engines: { node: '>=18' }
+
+    '@csstools/css-tokenizer@4.0.0':
+        resolution: { integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA== }
+        engines: { node: '>=20.19.0' }
 
     '@csstools/media-query-list-parser@4.0.3':
         resolution: { integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ== }
@@ -9875,6 +9903,12 @@ packages:
     postcss-scss@1.0.6:
         resolution: { integrity: sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww== }
 
+    postcss-scss@4.0.9:
+        resolution: { integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A== }
+        engines: { node: '>=12.0' }
+        peerDependencies:
+            postcss: ^8.4.29
+
     postcss-selector-parser@3.1.2:
         resolution: { integrity: sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA== }
         engines: { node: '>=8' }
@@ -11097,17 +11131,49 @@ packages:
         peerDependencies:
             stylelint: '>=11'
 
+    stylelint-config-recommended-scss@17.0.1:
+        resolution: { integrity: sha512-x5DVehzJudcwF0od3sGpgkln2PLLranFE7twwbp7dqDINCyZvwzFkMc6TLhNOvazRiVBJYATQLouJY0xPGB8WA== }
+        engines: { node: '>=20' }
+        peerDependencies:
+            postcss: ^8.3.3
+            stylelint: ^17.0.0
+        peerDependenciesMeta:
+            postcss:
+                optional: true
+
     stylelint-config-recommended@17.0.0:
         resolution: { integrity: sha512-WaMSdEiPfZTSFVoYmJbxorJfA610O0tlYuU2aEwY33UQhSPgFbClrVJYWvy3jGJx+XW37O+LyNLiZOEXhKhJmA== }
         engines: { node: '>=18.12.0' }
         peerDependencies:
             stylelint: ^16.23.0
 
+    stylelint-config-recommended@18.0.0:
+        resolution: { integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg== }
+        engines: { node: '>=20.19.0' }
+        peerDependencies:
+            stylelint: ^17.0.0
+
+    stylelint-config-standard-scss@17.0.0:
+        resolution: { integrity: sha512-uLJS6xgOCBw5EMsDW7Ukji8l28qRoMnkRch15s0qwZpskXvWt9oPzMmcYM307m9GN4MxuWLsQh4I6hU9yI53cQ== }
+        engines: { node: '>=20' }
+        peerDependencies:
+            postcss: ^8.3.3
+            stylelint: ^17.0.0
+        peerDependenciesMeta:
+            postcss:
+                optional: true
+
     stylelint-config-standard@39.0.1:
         resolution: { integrity: sha512-b7Fja59EYHRNOTa3aXiuWnhUWXFU2Nfg6h61bLfAb5GS5fX3LMUD0U5t4S8N/4tpHQg3Acs2UVPR9jy2l1g/3A== }
         engines: { node: '>=18.12.0' }
         peerDependencies:
             stylelint: ^16.23.0
+
+    stylelint-config-standard@40.0.0:
+        resolution: { integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw== }
+        engines: { node: '>=20.19.0' }
+        peerDependencies:
+            stylelint: ^17.0.0
 
     stylelint-order@6.0.4:
         resolution: { integrity: sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA== }
@@ -11126,6 +11192,12 @@ packages:
         engines: { node: '>=18.12.0' }
         peerDependencies:
             stylelint: ^16.8.2
+
+    stylelint-scss@7.2.0:
+        resolution: { integrity: sha512-6E79Bachv0Iz0gqRUZgdqdXCsiq26DWBWIBNHYtjTmAp3wJu6cp/I37VfW7BPntmh2puF3bY09XWl4HZGrLhzw== }
+        engines: { node: '>=20.19.0' }
+        peerDependencies:
+            stylelint: ^16.8.2 || ^17.0.0
 
     stylelint@16.26.1:
         resolution: { integrity: sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw== }
@@ -14250,15 +14322,30 @@ snapshots:
         dependencies:
             '@jridgewell/trace-mapping': 0.3.9
 
+    '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+        dependencies:
+            '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+            '@csstools/css-tokenizer': 4.0.0
+
     '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
         dependencies:
             '@csstools/css-tokenizer': 3.0.4
+
+    '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+        dependencies:
+            '@csstools/css-tokenizer': 4.0.0
 
     '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
         optionalDependencies:
             css-tree: 3.2.1
 
+    '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+        optionalDependencies:
+            css-tree: 3.2.1
+
     '@csstools/css-tokenizer@3.0.4': {}
+
+    '@csstools/css-tokenizer@4.0.0': {}
 
     '@csstools/media-query-list-parser@4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
         dependencies:
@@ -24187,6 +24274,10 @@ snapshots:
         dependencies:
             postcss: 6.0.23
 
+    postcss-scss@4.0.9(postcss@8.5.8):
+        dependencies:
+            postcss: 8.5.8
+
     postcss-selector-parser@3.1.2:
         dependencies:
             dot-prop: 5.3.0
@@ -25607,14 +25698,40 @@ snapshots:
             stylelint: 16.26.1(typescript@5.9.3)
             stylelint-order: 6.0.4(stylelint@16.26.1(typescript@5.9.3))
 
+    stylelint-config-recommended-scss@17.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3)):
+        dependencies:
+            postcss-scss: 4.0.9(postcss@8.5.8)
+            stylelint: 16.26.1(typescript@5.9.3)
+            stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@5.9.3))
+            stylelint-scss: 7.2.0(stylelint@16.26.1(typescript@5.9.3))
+        optionalDependencies:
+            postcss: 8.5.8
+
     stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@5.9.3)):
         dependencies:
             stylelint: 16.26.1(typescript@5.9.3)
+
+    stylelint-config-recommended@18.0.0(stylelint@16.26.1(typescript@5.9.3)):
+        dependencies:
+            stylelint: 16.26.1(typescript@5.9.3)
+
+    stylelint-config-standard-scss@17.0.0(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3)):
+        dependencies:
+            stylelint: 16.26.1(typescript@5.9.3)
+            stylelint-config-recommended-scss: 17.0.1(postcss@8.5.8)(stylelint@16.26.1(typescript@5.9.3))
+            stylelint-config-standard: 40.0.0(stylelint@16.26.1(typescript@5.9.3))
+        optionalDependencies:
+            postcss: 8.5.8
 
     stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@5.9.3)):
         dependencies:
             stylelint: 16.26.1(typescript@5.9.3)
             stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
+
+    stylelint-config-standard@40.0.0(stylelint@16.26.1(typescript@5.9.3)):
+        dependencies:
+            stylelint: 16.26.1(typescript@5.9.3)
+            stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@5.9.3))
 
     stylelint-order@6.0.4(stylelint@16.26.1(typescript@5.9.3)):
         dependencies:
@@ -25634,6 +25751,21 @@ snapshots:
             is-plain-object: 5.0.0
             known-css-properties: 0.37.0
             mdn-data: 2.27.1
+            postcss-media-query-parser: 0.2.3
+            postcss-resolve-nested-selector: 0.1.6
+            postcss-selector-parser: 7.1.1
+            postcss-value-parser: 4.2.0
+            stylelint: 16.26.1(typescript@5.9.3)
+
+    stylelint-scss@7.2.0(stylelint@16.26.1(typescript@5.9.3)):
+        dependencies:
+            '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+            '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+            '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+            '@csstools/css-tokenizer': 4.0.0
+            css-tree: 3.2.1
+            is-plain-object: 5.0.0
+            known-css-properties: 0.37.0
             postcss-media-query-parser: 0.2.3
             postcss-resolve-nested-selector: 0.1.6
             postcss-selector-parser: 7.1.1

--- a/projects/core/src/lib/idb-storage/idb-storage-service.ts
+++ b/projects/core/src/lib/idb-storage/idb-storage-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { Observable, Observer, Subscriber } from 'rxjs';
+import { Observable, Observer, Subscriber, take } from 'rxjs';
 
 import { WINDOW } from '../tokens';
 import { IIDBStorageServiceInterface } from './interfaces/idb-storage-service.interface';
@@ -25,7 +25,7 @@ export class IDBStorageService<ENTITY_TYPE> implements IIDBStorageServiceInterfa
 
     public get(key: string): Observable<ENTITY_TYPE | undefined> {
         return new Observable<ENTITY_TYPE | undefined>((observer: Subscriber<ENTITY_TYPE | undefined>) => {
-            this.#context.subscribe((db: IDBDatabase) => {
+            this.#context.pipe(take(1)).subscribe((db: IDBDatabase) => {
                 const transaction: IDBTransaction = db.transaction('idb', 'readonly');
                 const store: IDBObjectStore = transaction.objectStore('idb');
                 const request: IDBRequest<ENTITY_TYPE> = store.get(key);
@@ -38,7 +38,7 @@ export class IDBStorageService<ENTITY_TYPE> implements IIDBStorageServiceInterfa
 
     public set(key: string, value: ENTITY_TYPE): Observable<void> {
         return new Observable<void>((observer: Subscriber<void>) => {
-            this.#context.subscribe((db: IDBDatabase) => {
+            this.#context.pipe(take(1)).subscribe((db: IDBDatabase) => {
                 const transaction: IDBTransaction = db.transaction('idb', 'readwrite');
                 const store: IDBObjectStore = transaction.objectStore('idb');
                 const request: IDBRequest<IDBValidKey> = store.put(value, key);
@@ -51,7 +51,7 @@ export class IDBStorageService<ENTITY_TYPE> implements IIDBStorageServiceInterfa
 
     public remove(key: string): Observable<void> {
         return new Observable<void>((observer: Subscriber<void>) => {
-            this.#context.subscribe((db: IDBDatabase) => {
+            this.#context.pipe(take(1)).subscribe((db: IDBDatabase) => {
                 const transaction: IDBTransaction = db.transaction('idb', 'readwrite');
                 const store: IDBObjectStore = transaction.objectStore('idb');
                 const request: IDBRequest<undefined> = store.delete(key);

--- a/projects/store/src/lib/services/devtools-manager.service.ts
+++ b/projects/store/src/lib/services/devtools-manager.service.ts
@@ -102,6 +102,8 @@ export class DevToolsManagerService {
         this.#devTools.init(this.#getAggregatedState());
         this.#isInitialized = true;
 
+        // Redux DevTools extension API — not an RxJS Observable, so no terminating operator applies.
+        // eslint-disable-next-line rt/require-take-until-destroyed
         this.#devTools.subscribe((message: IDevToolsMessage) => {
             if (message.type === 'DISPATCH') {
                 switch (message.payload?.type) {

--- a/projects/ui-kit/.storybook/token-copy.ts
+++ b/projects/ui-kit/.storybook/token-copy.ts
@@ -1,6 +1,6 @@
 /**
  * Docs-wide enhancer: makes every inline `<code>` element whose text is exactly
- * a design-token name (`--rt-*` / `--clr-*`) copyable with one click.
+ * a design-token name (`--rt-*`) copyable with one click.
  *
  * React-safe by design: we only set `data-*` attributes on existing elements and
  * draw the copy icon via a CSS `::after` pseudo-element — no extra DOM nodes are

--- a/projects/ui-kit/docs/ColorSchemes.mdx
+++ b/projects/ui-kit/docs/ColorSchemes.mdx
@@ -1,0 +1,151 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Foundation/Theming/Custom color schemes" />
+
+# Custom color schemes (brand palettes)
+
+A **color scheme** lets a consuming app supply its own brand palette so the entire
+`--rt-*` accent layer resolves to that brand — in light, dark and auto — **without
+touching rt-tools internals and without duplicating the semantic tier**.
+
+It is orthogonal to light/dark: a scheme changes _which hue_ accents are, the theme
+changes _which tone_ of that hue renders per mode.
+
+---
+
+## How it works — the indirection contract
+
+The accent semantic tokens never hardcode a color. They reference a single
+indirection layer, the **accent-role ramps**:
+
+```
+--rt-color-{role}-{0..100}      ← the only thing a scheme overrides
+        │
+        ▼
+--rt-bg/text/icon/border-accent-{role}-*   ← derived once, in the kit
+--rt-border-focus
+```
+
+Roles: **`primary`, `info`, `success`, `warning`, `danger`, `brand`**.
+
+A scheme sets only the raw `--rt-color-{role}-{N}` rows. The kit derives everything
+else from them — one ramp per role serves both modes (the mode picks the tone via
+`light-dark()`; hover/subtle/disabled come from `color-mix()`). Schemes **never**
+re-declare the derivation layer.
+
+The scheme block is scoped to `[data-rt-scheme="<name>"]` on `<html>`. Because it
+sets raw values, it overrides the default rows (which carry the `--mat-sys-*`
+fallback) — so **a scheme wins over an active Material theme**.
+
+---
+
+## Recipe 1 — Sass (recommended, SSR-safe)
+
+```scss
+@use '@rt-tools/ui-kit/src/styles/main' as rt;
+
+@include rt.color-scheme(
+    'teal',
+    (
+        primary: (
+            20: #b3e3e1,
+            40: #5cb8b5,
+            60: #1a9d99,
+            100: #008582,
+        ),
+        brand: (
+            20: #e8e8e8,
+            100: #008582,
+        ),
+    )
+);
+```
+
+Emits:
+
+```css
+[data-rt-scheme='teal'] {
+    --rt-color-primary-20: #b3e3e1;
+    --rt-color-primary-40: #5cb8b5;
+    --rt-color-primary-60: #1a9d99;
+    --rt-color-primary-100: #008582;
+    --rt-color-brand-20: #e8e8e8;
+    --rt-color-brand-100: #008582;
+}
+```
+
+The mixin validates its input — an unknown role or an out-of-range tone (must be an
+integer 0–100) fails the build with an actionable message.
+
+## Recipe 2 — JavaScript (runtime, browser-only)
+
+The JS twin of the mixin, for schemes you don't know at build time. It injects an
+identical `[data-rt-scheme]` `<style>` block (no-op on the server — prefer the Sass
+path for brand-critical, SSR-rendered schemes):
+
+```typescript
+import { RtThemeService, RtColorSchemeRamp } from 'rt-tools';
+
+const teal: RtColorSchemeRamp = {
+    primary: { 20: '#b3e3e1', 40: '#5cb8b5', 60: '#1a9d99', 100: '#008582' },
+    brand: { 20: '#e8e8e8', 100: '#008582' },
+};
+
+const theme = inject(RtThemeService);
+theme.registerColorScheme('teal', teal); // make it available
+theme.setColorScheme('teal'); // activate it
+```
+
+---
+
+## Switching at runtime
+
+```typescript
+theme.setColorScheme('teal'); // activate (sets data-rt-scheme="teal" on <html>)
+theme.setColorScheme(null); // back to the default rt-tools palette
+theme.colorScheme(); // Signal<string | null> — the active scheme
+```
+
+- Orthogonal to `setTheme('light'|'dark'|'auto')` — combine freely.
+- Persisted to localStorage (`rt-color-scheme`) and restored on startup.
+- `null` or `'default'` clears the scheme (removes the attribute).
+
+| Concern       | API                                          | Storage key       | Attribute on `<html>` |
+| ------------- | -------------------------------------------- | ----------------- | --------------------- |
+| Light / dark  | `setTheme()` / `toggle()`                    | `rt-theme`        | `class="rt-dark"` …   |
+| Brand palette | `setColorScheme()` / `registerColorScheme()` | `rt-color-scheme` | `data-rt-scheme="…"`  |
+
+---
+
+## What a scheme drives
+
+Override `--rt-color-{role}-{N}` and these recolor automatically. The tones each
+default ramp anchors (provide at least these for a clean recolor):
+
+| Role      | Tones used by the kit | Drives                                                                                              |
+| --------- | --------------------- | --------------------------------------------------------------------------------------------------- |
+| `primary` | 20, 40, 60, 100       | `bg/text/icon/border-accent-primary-*`, `bg-accent-primary-{subtle,hover,disabled}`, `border-focus` |
+| `info`    | 20, 80, 100           | `bg/text/icon/border-accent-info-*`                                                                 |
+| `success` | 10, 80, 100           | `bg/text/icon/border-accent-success-*`                                                              |
+| `warning` | 10, 80, 100           | `bg/text/icon/border-accent-warning-*`                                                              |
+| `danger`  | 10, 60, 100           | `bg/text/icon/border-accent-danger-*`                                                               |
+| `brand`   | 20, 100               | `text-accent-brand`, `icon-accent-brand`                                                            |
+
+> `brand` is its own ramp (default navy `#0d1c2b`), independent of `primary`, so a
+> scheme can set brand ≠ primary. A partial ramp is allowed — unset tones keep the
+> rt-tools defaults (mixing brand and default hues, usually not what you want).
+
+---
+
+## Guarantees
+
+- **Δ0 default.** With no scheme, every accent token resolves byte-for-byte to the
+  historical own palette (regression-tested in `styles/color-scheme.spec.ts`).
+- **Stable contract.** Semantic token names never change — components don't care
+  which scheme is active.
+- **Generator parity.** The Sass mixin and `registerColorScheme()` emit identical
+  declarations for the same ramp (tested).
+- **Material.** The default honors `--mat-sys-*`; an active scheme overrides it.
+
+See **Foundation/Theming** for light/dark, and **Foundation/Design Tokens/Overview**
+for the `--mat-sys-*` fallback chains.

--- a/projects/ui-kit/docs/ColorSchemes.mdx
+++ b/projects/ui-kit/docs/ColorSchemes.mdx
@@ -137,6 +137,50 @@ default ramp anchors (provide at least these for a clean recolor):
 
 ---
 
+## Dark mode & the single-ramp model
+
+One ramp per role serves **both** modes — the mode picks _which tone_ renders:
+
+| Token group                             | Light         | Dark                                              |
+| --------------------------------------- | ------------- | ------------------------------------------------- |
+| `text/icon/border-accent-primary`       | `primary-100` | `primary-60`                                      |
+| `border-focus`                          | `primary-40`  | `primary-60`                                      |
+| `*-accent-{role}-solid`                 | tone-100/80   | same tone (mode-independent)                      |
+| `*-accent-{role}-subtle/hover/disabled` | tone-anchor   | **derived** via `color-mix()` from the solid tone |
+
+What this means for a brand:
+
+- **Solid / text / icon / border** are under your full control in **both** modes — you
+  pick the light value (e.g. `primary-100`) _and_ the dark value (`primary-60`)
+  independently by setting those tones. Set `primary-60` to your dark-mode brand color.
+- **subtle / hover / disabled** dark values are **computed** from your solid tone
+  (`color-mix` with the dark surface), not authored per-mode.
+
+So a brand reaches **Δ0 in dark** when it adopts this M3 tone-selection model — i.e. it
+expresses its dark palette as ramp tones rather than a hand-authored, separate dark
+block. If your app currently ships a bespoke `.dark-mode` accent block whose subtle/hover
+values don't match the `color-mix` derivation, those specific states will differ in dark
+(solid/text/icon/border still match exactly). Validate with a contract test against your
+real ramp in both modes before declaring Δ0.
+
+> The kit deliberately avoids `scheme × mode` ramp combinatorics (one ramp, not two).
+> If you need a fully hand-authored dark ramp distinct from light, raise it — it's a
+> conscious design boundary, not an oversight.
+
+---
+
+## Notes
+
+- **Specificity.** Blocks are emitted as `:root[data-rt-scheme="<name>"]` (0,2,0) so they
+  outrank the default `:root` rows (0,1,0) regardless of stylesheet order.
+- **No `-a{N}` scheme tokens.** For brand-tinted translucency use
+  `color-mix(in srgb, var(--rt-color-{role}-{N}) <pct>, transparent)` — it stays
+  scheme-reactive (Δ0) without a dedicated alpha row.
+- **CSS injection.** `registerColorScheme` writes role/tone/value into a `<style>` —
+  treat scheme names and values as developer-controlled (don't feed end-user input).
+
+---
+
 ## Guarantees
 
 - **Δ0 default.** With no scheme, every accent token resolves byte-for-byte to the
@@ -144,8 +188,10 @@ default ramp anchors (provide at least these for a clean recolor):
 - **Stable contract.** Semantic token names never change — components don't care
   which scheme is active.
 - **Generator parity.** The Sass mixin and `registerColorScheme()` emit identical
-  declarations for the same ramp (tested).
-- **Material.** The default honors `--mat-sys-*`; an active scheme overrides it.
+  declarations **and** apply the same input validation (unknown role / out-of-range
+  tone throw in both) — tested.
+- **Material.** The default honors `--mat-sys-*` (the fallback lives inside the ramp
+  tone); an active scheme replaces the tone with a raw value, so it overrides Material.
 
 See **Foundation/Theming** for light/dark, and **Foundation/Design Tokens/Overview**
 for the `--mat-sys-*` fallback chains.

--- a/projects/ui-kit/docs/Theming.mdx
+++ b/projects/ui-kit/docs/Theming.mdx
@@ -104,6 +104,16 @@ import { RtThemeDirective } from 'rt-tools';
 
 ---
 
+## Custom brand palettes
+
+Light/dark changes the _tone_; a **color scheme** changes the _hue_ — letting an app
+supply its own brand (e.g. teal) so the whole accent layer recolors without touching
+the kit. Schemes are orthogonal to the theme and switchable at runtime
+(`RtThemeService.setColorScheme('teal')`). See **Foundation/Theming/Custom color
+schemes**.
+
+---
+
 ## Angular Material interplay
 
 Material M3 themes built with `light-dark()` react to the same `color-scheme`

--- a/projects/ui-kit/docs/TokenColors.mdx
+++ b/projects/ui-kit/docs/TokenColors.mdx
@@ -40,20 +40,20 @@ white/gray/black families.
 
 <Strip items={[0, 5, 10, 15, 20, 25, 30, 35, 40, 60, 80, 100].map((n) => [`${n}`, `var(--rt-color-neutral-${n})`])} />
 
-| Token                    | Value     | Legacy alias      |
-| ------------------------ | --------- | ----------------- |
-| `--rt-color-neutral-0`   | `#ffffff` | `--clr-white-100` |
-| `--rt-color-neutral-5`   | `#f5f6f8` | `--clr-gray-5`    |
-| `--rt-color-neutral-10`  | `#f3f3f3` | `--clr-black-10`  |
-| `--rt-color-neutral-15`  | `#eeeeee` | `--clr-black-15`  |
-| `--rt-color-neutral-20`  | `#e8e8e8` | `--clr-gray-10`   |
-| `--rt-color-neutral-25`  | `#e0e0e0` | `--clr-black-20`  |
-| `--rt-color-neutral-30`  | `#d1d1d1` | `--clr-gray-15`   |
-| `--rt-color-neutral-35`  | `#cccccc` | `--clr-gray-20`   |
-| `--rt-color-neutral-40`  | `#a3a3a3` | `--clr-black-40`  |
-| `--rt-color-neutral-60`  | `#747474` | `--clr-black-60`  |
-| `--rt-color-neutral-80`  | `#323033` | `--clr-black-80`  |
-| `--rt-color-neutral-100` | `#181818` | `--clr-black-100` |
+| Token                    | Value     |
+| ------------------------ | --------- |
+| `--rt-color-neutral-0`   | `#ffffff` |
+| `--rt-color-neutral-5`   | `#f5f6f8` |
+| `--rt-color-neutral-10`  | `#f3f3f3` |
+| `--rt-color-neutral-15`  | `#eeeeee` |
+| `--rt-color-neutral-20`  | `#e8e8e8` |
+| `--rt-color-neutral-25`  | `#e0e0e0` |
+| `--rt-color-neutral-30`  | `#d1d1d1` |
+| `--rt-color-neutral-35`  | `#cccccc` |
+| `--rt-color-neutral-40`  | `#a3a3a3` |
+| `--rt-color-neutral-60`  | `#747474` |
+| `--rt-color-neutral-80`  | `#323033` |
+| `--rt-color-neutral-100` | `#181818` |
 
 ---
 
@@ -108,12 +108,3 @@ Two overlay sets for dimming / lightening surfaces:
 
 > Readability threshold ≈ 50%: below it an overlay is barely visible, above it
 > actively dims/lightens the background.
-
----
-
-## Deprecated aliases
-
-All legacy `--clr-*` variables are still emitted as aliases (see the
-**Legacy alias** column above; hue steps map 1:1, e.g. `--clr-red-100` →
-`--rt-color-red-100`). They will be removed in a future major release —
-do not use them in new code.

--- a/projects/ui-kit/docs/TokenWorkflow.mdx
+++ b/projects/ui-kit/docs/TokenWorkflow.mdx
@@ -73,15 +73,6 @@ Force the own palette (ignore Angular Material system colors):
 
 ---
 
-## Migration from `--clr-*`
-
-Legacy `--clr-{family}-{saturate}` variables (and `--clr-txt`,
-`--clr-base-accent`) are still emitted as deprecated aliases, so existing
-consumers keep working. Migrate to semantic tokens at your own pace; the
-aliases will be removed in a future major release.
-
----
-
 ## Figma parity
 
 The Figma library “RT-Tools UI Kit” mirrors this system: variable collections

--- a/projects/ui-kit/src/lib/ui-kit/action-bar/components/bar/rtui-action-bar.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/action-bar/components/bar/rtui-action-bar.component.scss
@@ -2,15 +2,15 @@
 @use '../../../../../styles/base/variables' as vars;
 
 .rtui-action-bar {
-    width: var(--rt-action-bar-bar-width);
     display: flex;
+    width: var(--rt-action-bar-bar-width);
     align-items: center;
-    gap: var(--rt-action-bar-bar-gap);
     padding: var(--rt-action-bar-bar-padding);
     border-radius: var(--rt-action-bar-bar-border-radius);
-    color: var(--rt-action-bar-bar-color);
     background-color: var(--rt-action-bar-bar-background-color);
     box-shadow: var(--rt-action-bar-bar-box-shadow);
+    color: var(--rt-action-bar-bar-color);
+    gap: var(--rt-action-bar-bar-gap);
 
     &__counter {
         font-size: var(--rt-action-bar-counter-font-size);
@@ -24,14 +24,14 @@
 
     &__action {
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: var(--rt-action-bar-action-gap);
-        font-size: var(--rt-action-bar-action-font-size);
-        font-weight: var(--rt-action-bar-action-font-weight);
+        justify-content: center;
         padding: var(--rt-action-bar-action-padding);
         border-radius: var(--rt-action-bar-action-border-radius);
         cursor: pointer;
+        font-size: var(--rt-action-bar-action-font-size);
+        font-weight: var(--rt-action-bar-action-font-weight);
+        gap: var(--rt-action-bar-action-gap);
 
         &:hover {
             background-color: var(--rt-action-bar-action-hover-background-color);
@@ -39,8 +39,8 @@
     }
 
     &__close-button {
-        cursor: pointer;
         margin-left: auto;
+        cursor: pointer;
 
         svg {
             transition: transform 0.2s ease;
@@ -52,16 +52,16 @@
     }
 
     @include mixins.media-breakpoint-down(vars.$device-md) {
-        gap: var(--rt-action-bar-bar-mobile-gap);
         padding: var(--rt-action-bar-bar-mobile-padding);
+        gap: var(--rt-action-bar-bar-mobile-gap);
 
         &__actions {
             gap: var(--rt-action-bar-actions-mobile-gap);
         }
 
         &__action {
-            gap: var(--rt-action-bar-action-mobile-gap);
             padding: var(--rt-action-bar-action-mobile-padding);
+            gap: var(--rt-action-bar-action-mobile-gap);
         }
     }
 }
@@ -69,23 +69,23 @@
 .rtui-action-bar-action-menu {
     display: flex;
     flex-direction: column;
-    gap: var(--rt-action-bar-action-menu-gap);
     padding: var(--rt-action-bar-action-menu-padding);
     border-radius: var(--rt-action-bar-action-border-radius);
-    color: var(--rt-action-bar-action-menu-color);
     background-color: var(--rt-action-bar-action-menu-background-color);
     box-shadow: var(--rt-action-bar-action-menu-box-shadow);
+    color: var(--rt-action-bar-action-menu-color);
+    gap: var(--rt-action-bar-action-menu-gap);
 
     &__action {
         display: flex;
-        justify-content: center;
         align-items: center;
-        gap: var(--rt-action-bar-action-menu-action-gap);
+        justify-content: center;
         padding: var(--rt-action-bar-action-menu-action-padding);
-        font-size: var(--rt-action-bar-action-menu-action-font-size);
-        font-weight: var(--rt-action-bar-action-menu-action-font-weight);
         border-radius: var(--rt-action-bar-action-menu-action-border-radius);
         cursor: pointer;
+        font-size: var(--rt-action-bar-action-menu-action-font-size);
+        font-weight: var(--rt-action-bar-action-menu-action-font-weight);
+        gap: var(--rt-action-bar-action-menu-action-gap);
 
         &:hover {
             background-color: var(--rt-action-bar-action-menu-action-hover-background-color);
@@ -93,12 +93,12 @@
     }
 
     @include mixins.media-breakpoint-down(vars.$device-md) {
-        gap: var(--rt-action-bar-action-menu-action-mobile-gap);
         padding: var(--rt-action-bar-action-menu-action-mobile-padding);
+        gap: var(--rt-action-bar-action-menu-action-mobile-gap);
 
         &__action {
-            gap: var(--rt-action-bar-action-menu-action-mobile-gap);
             padding: var(--rt-action-bar-action-menu-action-mobile-padding);
+            gap: var(--rt-action-bar-action-menu-action-mobile-gap);
         }
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/action-bar/components/container/rtui-action-bar-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/action-bar/components/container/rtui-action-bar-container.component.scss
@@ -1,12 +1,10 @@
 :host {
-    width: var(--rt-action-bar-container-width);
     position: fixed;
-    top: var(--rt-action-bar-container-top);
-    bottom: var(--rt-action-bar-container-bottom);
-    left: var(--rt-action-bar-container-left);
-    right: var(--rt-action-bar-container-right);
-    display: flex;
-    justify-content: center;
-    align-items: center;
     z-index: var(--rt-action-bar-container-z-index);
+    display: flex;
+    width: var(--rt-action-bar-container-width);
+    align-items: center;
+    justify-content: center;
+    inset: var(--rt-action-bar-container-top) var(--rt-action-bar-container-right) var(--rt-action-bar-container-bottom)
+        var(--rt-action-bar-container-left);
 }

--- a/projects/ui-kit/src/lib/ui-kit/aside/aside.service.ts
+++ b/projects/ui-kit/src/lib/ui-kit/aside/aside.service.ts
@@ -3,7 +3,7 @@ import { ComponentPortal, ComponentType } from '@angular/cdk/portal';
 import { ComponentRef, inject, Injectable, Injector } from '@angular/core';
 import { Event, NavigationEnd, Router } from '@angular/router';
 import { merge, Observable, of, Subject } from 'rxjs';
-import { delay, filter, tap } from 'rxjs/operators';
+import { delay, filter, take, tap } from 'rxjs/operators';
 
 import { ASIDE_REF, AsidePositions, AsideRef } from './aside.types';
 import { RtuiAsidePanelComponent } from './components/panel/aside-panel.component';
@@ -44,6 +44,9 @@ export class RtAsideService {
             answer.pipe(delay(10))
         )
             .pipe(
+                // The aside closes on the first of these events — terminate so the merged
+                // hot sources (router/backdrop/keydown) don't keep the subscription alive.
+                take(1),
                 tap((): void => {
                     componentRef.instance.startExitAnimation();
                     overlayRef.detach();

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/container/aside-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/container/aside-container.component.scss
@@ -3,6 +3,7 @@
         --rt-scrollable-header-padding: 0;
         --rt-scrollable-content-padding: 0;
         --rt-scrollable-footer-padding: 0;
+
         // TODO: fix styles affect x-scroll
         --rt-scrollable-content-flex-direction: row;
 

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/error-notification/aside-error-box.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/error-notification/aside-error-box.component.scss
@@ -4,18 +4,18 @@
 
     .aside-error-box {
         display: flex;
-        justify-content: space-between;
-        align-items: center;
         width: 100%;
         height: var(--rt-aside-error-box-height);
+        align-items: center;
+        justify-content: space-between;
         padding: var(--rt-aside-error-box-padding);
-        margin: var(--rt-aside-error-box-margin);
         border: var(--rt-aside-error-box-border);
         border-radius: var(--rt-aside-error-box-border-radius);
+        margin: var(--rt-aside-error-box-margin);
 
         &__title {
-            font-size: var(--rt-aside-error-box-title-font-size);
             color: var(--rt-aside-error-box-title-font-color);
+            font-size: var(--rt-aside-error-box-title-font-size);
         }
 
         .aside-error-box-button {
@@ -24,8 +24,8 @@
             }
 
             &__title {
-                font-size: var(--rt-aside-error-box-button-font-size);
                 color: var(--rt-aside-error-box-button-font-color);
+                font-size: var(--rt-aside-error-box-button-font-size);
             }
 
             &.--complete {

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/error-notification/aside-error-box.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/error-notification/aside-error-box.component.scss
@@ -20,7 +20,7 @@
 
         .aside-error-box-button {
             &__icon {
-                margin-right: 0.5rem;
+                margin-right: var(--rt-spacing-8);
             }
 
             &__title {

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
@@ -77,7 +77,7 @@ $aside: (
 );
 
 // NOTE: emitted at :root on purpose (ViewEncapsulation.None): consumers override
-// these vars from ancestor scopes (e.g. Avalon's `.dark-mode { --rt-aside-host-background-color: … }`).
+// these vars from ancestor scopes (e.g. a consumer's `.dark-mode { --rt-aside-host-background-color: … }`).
 // Emitting at :host would set values on the element itself and silently win over
 // inherited overrides — do not "fix" this to :host.
 :root {

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
@@ -98,7 +98,7 @@ $aside: (
 
 .title-badge {
     top: -0.5rem;
-    margin-left: 0.25rem;
+    margin-left: var(--rt-spacing-4);
 }
 
 .icon-badge,

--- a/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/components/panel/aside-panel.component.scss
@@ -4,7 +4,7 @@
 $aside: (
     host: (
         width: 33.75rem,
-        box-shadow: 0 0 1rem 0 rgba(#000, 0.1),
+        box-shadow: 0 0 1rem 0 var(--rt-color-dark-a10),
         background-color: var(--rt-bg-base-base),
     ),
     header: (
@@ -45,7 +45,7 @@ $aside: (
     ),
     footer: (
         padding: 2rem,
-        margin-left-betwen-buttons: 1rem,
+        margin-left-between-buttons: 1rem,
     ),
     footer-mobile: (
         padding: 1rem,
@@ -76,22 +76,19 @@ $aside: (
     ),
 );
 
+// NOTE: emitted at :root on purpose (ViewEncapsulation.None): consumers override
+// these vars from ancestor scopes (e.g. Avalon's `.dark-mode { --rt-aside-host-background-color: … }`).
+// Emitting at :host would set values on the element itself and silently win over
+// inherited overrides — do not "fix" this to :host.
 :root {
     @each $element, $elements in $aside {
         @each $style-token, $value in $elements {
             #{mixins.generateCssVar('aside', #{$element}, #{$style-token})}: #{$value};
         }
     }
-}
 
-.cdk-overlay-container,
-.cdk-overlay-pane {
-    z-index: 9999;
-}
-
-// TAB GROUP
-.mat-mdc-tab-group {
-    width: 100%;
+    // @deprecated — typo kept as alias for backward compatibility; use *-between-* instead.
+    --rt-aside-footer-margin-left-betwen-buttons: var(--rt-aside-footer-margin-left-between-buttons);
 }
 
 // BADGE
@@ -100,8 +97,8 @@ $aside: (
 }
 
 .title-badge {
-    margin-left: 0.25rem;
     top: -0.5rem;
+    margin-left: 0.25rem;
 }
 
 .icon-badge,
@@ -121,12 +118,11 @@ $aside: (
 // ASIDE
 .c-aside {
     position: relative;
+    width: var(--rt-aside-host-width);
     height: 100vh;
     max-height: 100vh;
-    width: var(--rt-aside-host-width);
-
-    box-shadow: var(--rt-aside-host-box-shadow);
     background-color: var(--rt-aside-host-background-color);
+    box-shadow: var(--rt-aside-host-box-shadow);
 
     // TAB GROUP
     .mdc-tab-indicator__content.mdc-tab-indicator__content--underline {
@@ -147,38 +143,38 @@ $aside: (
     }
 
     .c-aside-title {
-        height: 100%;
-        width: 100%;
         display: flex;
+        width: 100%;
+        height: 100%;
         flex-direction: column;
-        justify-content: center;
         align-items: flex-start;
+        justify-content: center;
 
         &__descr {
             margin-bottom: var(--rt-aside-header-description-margin-bottom);
-            font-size: var(--rt-aside-header-description-font-size);
             color: var(--rt-aside-header-description-color);
+            font-size: var(--rt-aside-header-description-font-size);
         }
 
         &__txt {
             font-size: var(--rt-aside-header-title-font-size);
-            line-height: var(--rt-aside-header-title-line-height);
             font-weight: var(--rt-aside-header-title-font-weight);
+            line-height: var(--rt-aside-header-title-line-height);
         }
 
         &__addition {
             margin-top: var(--rt-aside-header-addition-margin-top);
-            font-size: var(--rt-aside-header-addition-font-size);
             color: var(--rt-aside-header-addition-color);
+            font-size: var(--rt-aside-header-addition-font-size);
         }
 
         &__descr,
         &__txt,
         &__addition {
-            width: 100%;
-            white-space: nowrap;
             overflow: hidden;
+            width: 100%;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 
@@ -196,21 +192,19 @@ $aside: (
 } // c-aside-header
 
 .c-aside-content {
-    height: 100%;
-    width: 100%;
-
     display: flex;
+    width: 100%;
+    height: 100%;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-
     padding: var(--rt-aside-content-padding);
 
     // Change mat tab group styles
     .mat-mdc-tab-header {
-        top: 0;
-        z-index: 1000;
         position: sticky;
+        z-index: 1000;
+        top: 0;
         background: var(--rt-bg-base-base);
     }
 
@@ -222,9 +216,8 @@ $aside: (
 // ASIDE FOOTER
 .c-aside-footer {
     display: flex;
-    justify-content: flex-end;
     align-items: center;
-
+    justify-content: flex-end;
     padding: var(--rt-aside-footer-padding);
 
     .c-aside-footer-btn {
@@ -234,7 +227,7 @@ $aside: (
     }
 
     .c-aside-footer-btn + .c-aside-footer-btn {
-        margin-left: var(--rt-aside-footer-margin-left-betwen-buttons);
+        margin-left: var(--rt-aside-footer-margin-left-between-buttons);
     }
 
     @include mixins.media-breakpoint-down(vars.$device-xs) {

--- a/projects/ui-kit/src/lib/ui-kit/aside/stories/aside-component/test-aside.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/aside/stories/aside-component/test-aside.component.scss
@@ -1,4 +1,4 @@
 :host {
-    height: 100%;
     width: 100%;
+    height: 100%;
 }

--- a/projects/ui-kit/src/lib/ui-kit/buttons/icon-round/rtui-round-icon-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/icon-round/rtui-round-icon-button.component.scss
@@ -20,13 +20,13 @@ $round-icon-button: (
     }
 
     .round-icon-button {
+        z-index: var(--rt-round-icon-button-host-z-index);
         display: flex;
-        justify-content: center;
-        align-items: center;
         width: var(--rt-round-icon-button-host-size);
         height: var(--rt-round-icon-button-host-size);
+        align-items: center;
+        justify-content: center;
         padding: var(--rt-round-icon-button-host-padding);
-        z-index: var(--rt-round-icon-button-host-z-index);
         border-radius: 50%;
         cursor: pointer;
 

--- a/projects/ui-kit/src/lib/ui-kit/buttons/icon-round/rtui-round-icon-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/icon-round/rtui-round-icon-button.component.scss
@@ -27,7 +27,7 @@ $round-icon-button: (
         align-items: center;
         justify-content: center;
         padding: var(--rt-round-icon-button-host-padding);
-        border-radius: 50%;
+        border-radius: var(--rt-radius-full);
         cursor: pointer;
 
         &__icon {

--- a/projects/ui-kit/src/lib/ui-kit/buttons/multi-button/rtui-multi-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/multi-button/rtui-multi-button.component.scss
@@ -48,24 +48,24 @@ $rtui-multibutton: (
     .rtui-multibutton-actions {
         display: var(--rt-rtui-multibutton-base-display);
         flex-flow: var(--rt-rtui-multibutton-base-flex-flow);
-        border-radius: var(--rt-rtui-multibutton-base-radius);
         padding: var(--rt-rtui-multibutton-base-padding);
+        border-radius: var(--rt-rtui-multibutton-base-radius);
         background-color: var(--rt-rtui-multibutton-base-background-color);
 
         &__action {
             padding: var(--rt-rtui-multibutton-action-base-padding);
-            border-radius: var(--rt-rtui-multibutton-action-base-radius);
             border: var(--rt-rtui-multibutton-action-base-border);
+            border-radius: var(--rt-rtui-multibutton-action-base-radius);
+            background-color: var(--rt-rtui-multibutton-action-base-background-color);
+            color: var(--rt-rtui-multibutton-action-base-color);
+            cursor: var(--rt-rtui-multibutton-action-base-cursor);
             font-size: var(--rt-rtui-multibutton-action-base-font-size);
             font-weight: var(--rt-rtui-multibutton-action-base-font-weight);
-            color: var(--rt-rtui-multibutton-action-base-color);
-            background-color: var(--rt-rtui-multibutton-action-base-background-color);
             transition: var(--rt-rtui-multibutton-action-base-transition);
-            cursor: var(--rt-rtui-multibutton-action-base-cursor);
 
             &--active {
-                color: var(--rt-rtui-multibutton-action-active-color);
                 background-color: var(--rt-rtui-multibutton-action-active-background-color);
+                color: var(--rt-rtui-multibutton-action-active-color);
                 cursor: var(--rt-rtui-multibutton-action-active-cursor);
             }
 
@@ -83,9 +83,9 @@ $rtui-multibutton: (
             }
 
             &:disabled {
-                pointer-events: var(--rt-rtui-multibutton-action-disabled-pointer-events);
                 cursor: var(--rt-rtui-multibutton-action-disabled-cursor);
                 opacity: var(--rt-rtui-multibutton-action-disabled-opacity);
+                pointer-events: var(--rt-rtui-multibutton-action-disabled-pointer-events);
             }
         }
     }

--- a/projects/ui-kit/src/lib/ui-kit/buttons/multi-button/rtui-multi-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/multi-button/rtui-multi-button.component.ts
@@ -9,7 +9,7 @@ import {
     model,
     output,
 } from '@angular/core';
-import { BlockDirective, ElemDirective } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective } from '@rt-tools/core';
 import { transformArrayInput } from '@rt-tools/utils';
 
 @Component({
@@ -23,6 +23,7 @@ import { transformArrayInput } from '@rt-tools/utils';
         // rt-tools
         BlockDirective,
         ElemDirective,
+        ModDirective,
     ],
 })
 export class RtuiMultiButtonComponent {

--- a/projects/ui-kit/src/lib/ui-kit/checkbox/rtui-checkbox.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/checkbox/rtui-checkbox.component.scss
@@ -5,22 +5,22 @@
     gap: var(--rt-checkbox-container-gap);
 
     &__input {
-        @include mixins.visually-hidden();
+        @include mixins.visually-hidden;
     }
 
     &__box {
         display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
         width: var(--rt-checkbox-box-width);
         height: var(--rt-checkbox-box-height);
+        flex-shrink: 0;
+        align-items: center;
+        justify-content: center;
         border: var(--rt-checkbox-box-border);
         border-radius: var(--rt-checkbox-box-border-radius);
-        color: var(--rt-checkbox-box-inactive-color);
         background-color: var(--rt-checkbox-box-background-color);
-        transition: border-color 0.15s linear;
+        color: var(--rt-checkbox-box-inactive-color);
         cursor: pointer;
+        transition: border-color 0.15s linear;
 
         svg {
             opacity: 0;
@@ -30,8 +30,8 @@
 
     &__input:checked + &__box,
     &__input:indeterminate + &__box {
-        color: var(--rt-checkbox-box-active-color);
         border-color: var(--rt-checkbox-box-active-color);
+        color: var(--rt-checkbox-box-active-color);
 
         svg {
             opacity: 1;
@@ -39,8 +39,8 @@
     }
 
     &__input:disabled + &__box {
-        color: var(--rt-text-base-disabled);
         border-color: var(--rt-border-neutral-strong);
+        color: var(--rt-text-base-disabled);
         cursor: default;
     }
 
@@ -54,15 +54,15 @@
     }
 
     &__label {
+        color: var(--rt-checkbox-label-color);
         font-size: var(--rt-checkbox-label-font-size);
         font-weight: var(--rt-checkbox-label-font-weight);
-        color: var(--rt-checkbox-label-color);
     }
 
     &__description {
         margin-top: var(--rt-checkbox-description-margin-top);
+        color: var(--rt-checkbox-description-color);
         font-size: var(--rt-checkbox-description-font-size);
         font-weight: var(--rt-checkbox-description-font-weight);
-        color: var(--rt-checkbox-description-color);
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/checkbox/stories/component/test-checkbox.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/checkbox/stories/component/test-checkbox.component.scss
@@ -1,9 +1,9 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     margin: -1rem;
 }

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/actions/rtui-dynamic-selector-list-actions.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/actions/rtui-dynamic-selector-list-actions.component.scss
@@ -29,14 +29,14 @@ $dynamic-selector-list-actions: (
 
     display: flex;
     align-items: center;
-    margin-left: auto;
     padding-right: var(--rt-dynamic-selector-list-actions-host-padding-right);
+    margin-left: auto;
 
     .rtui-dynamic-selector-list-actions {
         display: flex;
         align-items: center;
-        margin-left: auto;
         padding-right: var(--rt-dynamic-selector-list-actions-padding-right);
+        margin-left: auto;
 
         &__control {
             padding: var(--rt-dynamic-selector-list-actions-control-padding);

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/actions/rtui-dynamic-selector-list-actions.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/actions/rtui-dynamic-selector-list-actions.component.ts
@@ -11,14 +11,14 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { RtIconOutlinedDirective } from '@rt-tools/utils';
 
 @Component({
     selector: 'rtui-dynamic-selector-list-actions',
     templateUrl: './rtui-dynamic-selector-list-actions.component.html',
     styleUrls: ['./rtui-dynamic-selector-list-actions.component.scss'],
-    imports: [MatIcon, MatButton, RtIconOutlinedDirective, BlockDirective, ElemDirective, MatIconButton, MatTooltip],
+    imports: [MatIcon, MatButton, RtIconOutlinedDirective, BlockDirective, ElemDirective, ModDirective, MatIconButton, MatTooltip],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RtuiDynamicSelectorListActionsComponent {

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/dynamic-selector/rtui-dynamic-selector.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/dynamic-selector/rtui-dynamic-selector.component.scss
@@ -1,7 +1,7 @@
 :host {
-    height: 100%;
-    width: 100%;
     display: flex;
-    flex-direction: column;
     overflow: hidden;
+    width: 100%;
+    height: 100%;
+    flex-direction: column;
 }

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.scss
@@ -73,13 +73,13 @@ $multi-selector: (
     }
 
     display: flex;
-    flex-direction: column;
     width: var(--rt-multi-selector-host-width);
     height: var(--rt-multi-selector-host-height);
+    flex-direction: column;
     padding: var(--rt-multi-selector-host-padding);
-    box-shadow: var(--rt-multi-selector-host-box-shadow);
     border-radius: var(--rt-multi-selector-host-border-radius);
     background-color: var(--rt-multi-selector-host-background-color);
+    box-shadow: var(--rt-multi-selector-host-box-shadow);
 
     &::ng-deep {
         // radiobutton
@@ -141,8 +141,8 @@ $multi-selector: (
 
                 &-info {
                     margin-left: var(--rt-multi-selector-header-controls-item-info-margin-left);
-                    font-size: var(--rt-multi-selector-header-controls-item-info-font-size);
                     color: var(--rt-multi-selector-header-controls-item-info-color);
+                    font-size: var(--rt-multi-selector-header-controls-item-info-font-size);
                 }
             }
         }
@@ -150,19 +150,19 @@ $multi-selector: (
 
     .rtui-multi-selector-options {
         display: flex;
-        flex-direction: column;
-        flex: 1 1 100%;
-        height: 100%;
         width: 100%;
+        height: 100%;
+        flex: 1 1 100%;
+        flex-direction: column;
         overflow-y: auto;
 
         &__item {
             &-title {
+                overflow: hidden;
                 width: 100%;
                 max-width: var(--rt-multi-selector-options-item-title-max-width);
-                white-space: nowrap;
-                overflow: hidden;
                 text-overflow: ellipsis;
+                white-space: nowrap;
             }
 
             &--separated {
@@ -172,38 +172,38 @@ $multi-selector: (
 
         &__loader {
             display: flex;
-            justify-content: center;
             align-items: center;
+            justify-content: center;
         }
     }
 
     .rtui-multi-selector-placeholder {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
         flex: 1 1 100%;
-        gap: var(--rt-multi-selector-placeholder-gap);
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
         padding-right: var(--rt-multi-selector-placeholder-padding-right);
+        gap: var(--rt-multi-selector-placeholder-gap);
         overflow-y: auto;
 
         &__icon {
             width: var(--rt-multi-selector-placeholder-icon-size);
             height: var(--rt-multi-selector-placeholder-icon-size);
-            font-size: var(--rt-multi-selector-placeholder-icon-size);
             color: var(--rt-multi-selector-placeholder-icon-color);
+            font-size: var(--rt-multi-selector-placeholder-icon-size);
         }
 
         &__title {
-            font-size: var(--rt-multi-selector-placeholder-title-font-size);
             color: var(--rt-multi-selector-placeholder-title-color);
+            font-size: var(--rt-multi-selector-placeholder-title-font-size);
         }
     }
 
     .rtui-multi-selector-footer {
         display: flex;
-        justify-content: flex-end;
         align-items: center;
+        justify-content: flex-end;
         padding: var(--rt-multi-selector-footer-padding);
         gap: var(--rt-multi-selector-footer-gap);
 
@@ -212,9 +212,9 @@ $multi-selector: (
         }
 
         &__nav-action {
-            text-decoration: none;
-            font-size: var(--rt-multi-selector-footer-nav-action-font-size);
             color: var(--rt-multi-selector-footer-nav-action-color);
+            font-size: var(--rt-multi-selector-footer-nav-action-font-size);
+            text-decoration: none;
 
             &:hover {
                 color: var(--rt-multi-selector-footer-nav-action-hover-color);

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.ts
@@ -33,7 +33,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { debounceTime } from 'rxjs/operators';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import {
     BreakStringPipe,
     DeviceDetectorService,
@@ -73,6 +73,7 @@ import { BooleanInput } from '@angular/cdk/coercion';
         // directives
         BlockDirective,
         ElemDirective,
+        ModDirective,
         RtScrollDirective,
         RtIconOutlinedDirective,
 

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/placeholder/rtui-dynamic-selector-placeholder.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/placeholder/rtui-dynamic-selector-placeholder.component.scss
@@ -28,11 +28,10 @@ $dynamic-selector-placeholder: (
         }
     }
 
+    display: flex;
     width: var(--rt-dynamic-selector-placeholder-host-width);
     height: var(--rt-dynamic-selector-placeholder-host-height);
     min-height: var(--rt-dynamic-selector-placeholder-host-min-height);
-
-    display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -42,8 +41,8 @@ $dynamic-selector-placeholder: (
         &__icon {
             width: var(--rt-dynamic-selector-placeholder-icon-size);
             height: var(--rt-dynamic-selector-placeholder-icon-size);
-            font-size: var(--rt-dynamic-selector-placeholder-icon-size);
             color: var(--rt-dynamic-selector-placeholder-icon-color);
+            font-size: var(--rt-dynamic-selector-placeholder-icon-size);
 
             &--warn {
                 color: var(--rt-dynamic-selector-placeholder-icon-warn-color);
@@ -51,9 +50,9 @@ $dynamic-selector-placeholder: (
         }
 
         &__description {
+            color: var(--rt-dynamic-selector-placeholder-description-color);
             font-size: var(--rt-dynamic-selector-placeholder-description-font-size);
             line-height: var(--rt-dynamic-selector-placeholder-description-line-height);
-            color: var(--rt-dynamic-selector-placeholder-description-color);
         }
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/placeholder/rtui-dynamic-selector-placeholder.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/placeholder/rtui-dynamic-selector-placeholder.component.ts
@@ -11,14 +11,14 @@ import {
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 
-import { BlockDirective, ElemDirective } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective } from '@rt-tools/core';
 import { RtIconOutlinedDirective, transformStringInput } from '@rt-tools/utils';
 
 @Component({
     selector: 'rtui-dynamic-selector-placeholder',
     templateUrl: './rtui-dynamic-selector-placeholder.component.html',
     styleUrls: ['./rtui-dynamic-selector-placeholder.component.scss'],
-    imports: [MatIcon, MatButton, CdkOverlayOrigin, RtIconOutlinedDirective, BlockDirective, ElemDirective],
+    imports: [MatIcon, MatButton, CdkOverlayOrigin, RtIconOutlinedDirective, BlockDirective, ElemDirective, ModDirective],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RtuiDynamicSelectorPlaceholderComponent {

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/selected-list/rtui-dynamic-selector-selected-list.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/selected-list/rtui-dynamic-selector-selected-list.component.scss
@@ -27,9 +27,9 @@
 }
 
 .cdk-drag-preview {
-    border: none;
     box-sizing: border-box;
+    border: none;
     border-radius: var(--rt-dynamic-selector-item-border-radius);
-    box-shadow: var(--rt-dynamic-selector-item-drag-preview-box-shadow);
     background: var(--mat-option-selected-state-layer-color);
+    box-shadow: var(--rt-dynamic-selector-item-drag-preview-box-shadow);
 }

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/selected-list/rtui-dynamic-selector-selected-list.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/selected-list/rtui-dynamic-selector-selected-list.component.ts
@@ -21,7 +21,7 @@ import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { BreakStringPipe, EntityToStringPipe, RtHideTooltipDirective, RtIconOutlinedDirective, transformArrayInput } from '@rt-tools/utils';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -66,6 +66,7 @@ export class RtuiDynamicSelectorItemTitleDirective {}
         RtHideTooltipDirective,
         BlockDirective,
         ElemDirective,
+        ModDirective,
 
         // pipes
         EntityToStringPipe,

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/strories/component/input/test-dynamic-input.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/strories/component/input/test-dynamic-input.component.scss
@@ -1,11 +1,10 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-
-    display: flex;
     flex-direction: column;
-    justify-content: flex-start;
     align-items: center;
+    justify-content: flex-start;
     margin: -1rem;
 
     rtui-dynamic-input {

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/strories/component/selector/test-selector.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/strories/component/selector/test-selector.component.scss
@@ -1,11 +1,10 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-
-    display: flex;
     flex-direction: column;
-    justify-content: flex-start;
     align-items: center;
+    justify-content: flex-start;
     margin: -1rem;
 
     rtui-dynamic-selector {
@@ -23,13 +22,13 @@
     .custom-title {
         display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
         font-size: 0.875rem;
+        gap: 0.5rem;
 
         &__icon {
-            font-size: 1.125rem;
             width: 1.125rem;
             height: 1.125rem;
+            font-size: 1.125rem;
         }
 
         &__id {

--- a/projects/ui-kit/src/lib/ui-kit/file-uploader/rtui-file-upload.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/file-uploader/rtui-file-upload.component.scss
@@ -35,18 +35,18 @@ $file-upload: (
         }
     }
 
+    display: var(--rt-file-upload-host-display);
     width: var(--rt-file-upload-host-width);
     max-width: var(--rt-file-upload-host-max-width);
     height: var(--rt-file-upload-host-height);
     max-height: var(--rt-file-upload-host-max-height);
-    display: var(--rt-file-upload-host-display);
     flex-direction: var(--rt-file-upload-host-flex-direction);
-    justify-content: var(--rt-file-upload-host-justify-content);
     align-items: var(--rt-file-upload-host-align-items);
-    gap: var(--rt-file-upload-host-gap);
+    justify-content: var(--rt-file-upload-host-justify-content);
     padding: var(--rt-file-upload-host-padding);
     border: var(--rt-file-upload-host-border);
     border-radius: var(--rt-file-upload-host-border-radius);
+    gap: var(--rt-file-upload-host-gap);
     transition: border-color 0.3s ease-in-out;
 
     &.--dragged {
@@ -57,13 +57,13 @@ $file-upload: (
         &__icon {
             width: var(--rt-file-upload-icon-size);
             height: var(--rt-file-upload-icon-size);
-            font-size: var(--rt-file-upload-icon-size);
             color: var(--rt-file-upload-icon-color);
+            font-size: var(--rt-file-upload-icon-size);
         }
 
         &__title {
-            font-size: var(--rt-file-upload-title-font-size);
             color: var(--rt-file-upload-title-color);
+            font-size: var(--rt-file-upload-title-font-size);
         }
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/file-uploader/stories/component/test-file-upload.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/file-uploader/stories/component/test-file-upload.component.scss
@@ -1,6 +1,6 @@
 :host {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 }

--- a/projects/ui-kit/src/lib/ui-kit/header/header.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/header/header.component.scss
@@ -1,0 +1,1 @@
+// Intentionally empty — header is styled entirely via host bindings and Material theme vars.

--- a/projects/ui-kit/src/lib/ui-kit/header/stories/component/test-header.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/header/stories/component/test-header.component.scss
@@ -1,14 +1,14 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
     margin: -1rem;
 
     .content {
-        flex-grow: 1;
         display: flex;
-        justify-content: center;
+        flex-grow: 1;
         align-items: center;
+        justify-content: center;
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/image-uploader/image-uploader/rtui-image-upload.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/image-uploader/image-uploader/rtui-image-upload.component.scss
@@ -40,15 +40,15 @@ $image-upload: (
         }
     }
 
+    display: var(--rt-image-upload-host-display);
     width: var(--rt-image-upload-host-width);
     min-width: var(--rt-image-upload-host-min-height);
     max-width: var(--rt-image-upload-host-max-width);
     height: var(--rt-image-upload-host-height);
     min-height: var(--rt-image-upload-host-min-height);
     max-height: var(--rt-image-upload-host-max-height);
-    display: var(--rt-image-upload-host-display);
-    justify-content: var(--rt-image-upload-host-justify-content);
     align-items: var(--rt-image-upload-host-align-items);
+    justify-content: var(--rt-image-upload-host-justify-content);
 
     .rtui-image-cropper {
         padding: var(--rt-image-upload-image-cropper-padding);
@@ -56,8 +56,8 @@ $image-upload: (
         &__actions {
             display: var(--rt-image-upload-image-cropper-actions-display);
             justify-content: var(--rt-image-upload-image-cropper-actions-justify-content);
-            gap: var(--rt-image-upload-image-cropper-actions-gap);
             margin-top: var(--rt-image-upload-image-cropper-actions-justify-margin-top);
+            gap: var(--rt-image-upload-image-cropper-actions-gap);
         }
     }
 
@@ -73,8 +73,8 @@ $image-upload: (
             pointer-events: none;
 
             &--active {
-                pointer-events: initial;
                 cursor: pointer;
+                pointer-events: initial;
 
                 &:hover {
                     opacity: 0.6;
@@ -84,9 +84,9 @@ $image-upload: (
 
         &__action {
             position: absolute;
+            z-index: 999;
             top: 0;
             right: 0;
-            z-index: 999;
             backdrop-filter: blur(1.25rem);
         }
     }

--- a/projects/ui-kit/src/lib/ui-kit/image-uploader/image-uploader/rtui-image-upload.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/image-uploader/image-uploader/rtui-image-upload.component.ts
@@ -21,7 +21,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatTooltip, TooltipPosition } from '@angular/material/tooltip';
 import { ImageCroppedEvent, ImageCropperComponent } from 'ngx-image-cropper';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { RtIconOutlinedDirective, transformStringInput } from '@rt-tools/utils';
 import { RtuiFileUploadComponent } from '../../file-uploader';
 import { RtuiSpinnerComponent } from '../../spinner';
@@ -46,6 +46,7 @@ export type IImageUploadFormat = 'png' | 'jpeg' | 'webp';
 
         // rt-tools
         ElemDirective,
+        ModDirective,
         BlockDirective,
         RtuiSpinnerComponent,
         RtuiFileUploadComponent,

--- a/projects/ui-kit/src/lib/ui-kit/image-uploader/stories/component/test-image-upload.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/image-uploader/stories/component/test-image-upload.component.scss
@@ -1,9 +1,9 @@
 :host {
+    display: flex;
     width: 20rem;
     height: 30rem;
-    display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     margin: 1rem;
 }

--- a/projects/ui-kit/src/lib/ui-kit/info-badge/info-badge.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/info-badge/info-badge.component.scss
@@ -1,7 +1,7 @@
 :host {
     display: block;
     max-width: fit-content;
-    border-radius: 9999px;
+    border-radius: var(--rt-radius-full);
 
     // default values (overridable by consumers; runtime variants set inline styles via InfoBadgeDirective)
     /* stylelint-disable-next-line color-no-hex -- default brand blue has no palette token on purpose */
@@ -14,7 +14,7 @@
         box-sizing: border-box;
         align-items: center;
         justify-content: center;
-        gap: 0.15rem;
+        gap: var(--rt-spacing-2);
         line-height: normal;
 
         &__content {
@@ -25,30 +25,30 @@
     }
 
     .size-l {
-        padding: 0.3rem 0.65rem;
-        font-size: 1.125rem;
+        padding: var(--rt-spacing-4) var(--rt-spacing-12);
+        font-size: var(--rt-font-size-md);
 
         .mat-icon {
-            font-size: 1.5rem;
+            font-size: var(--rt-font-size-xl);
         }
     }
 
     .size-m {
-        padding: 0.22rem 0.65rem;
-        font-size: 0.875rem;
+        padding: var(--rt-spacing-4) var(--rt-spacing-12);
+        font-size: var(--rt-font-size-sm);
 
         .mat-icon {
-            font-size: 1.05rem;
+            font-size: var(--rt-font-size-md);
         }
     }
 
     .size-s {
-        padding: 0.2rem 0.65rem;
-        font-size: 0.75rem;
+        padding: var(--rt-spacing-4) var(--rt-spacing-12);
+        font-size: var(--rt-font-size-xs);
         letter-spacing: 0.025rem;
 
         .mat-icon {
-            font-size: 0.75rem;
+            font-size: var(--rt-font-size-xs);
         }
     }
 
@@ -58,6 +58,6 @@
     }
 
     .bold {
-        font-weight: 700;
+        font-weight: var(--rt-font-weight-bold);
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/info-badge/info-badge.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/info-badge/info-badge.component.scss
@@ -1,31 +1,32 @@
 :host {
-    border-radius: 9999px;
     display: block;
-    line-height: normal;
     max-width: fit-content;
+    border-radius: 9999px;
 
-    // default values
-    background-color: #005cbb;
-    color: #ffffff;
+    // default values (overridable by consumers; runtime variants set inline styles via InfoBadgeDirective)
+    /* stylelint-disable-next-line color-no-hex -- default brand blue has no palette token on purpose */
+    background-color: var(--rt-info-badge-background-color, #005cbb);
+    color: var(--rt-info-badge-color, var(--rt-text-static-light));
+    line-height: normal;
 
     .c-info-badge {
         display: flex;
-        gap: 0.15rem;
+        box-sizing: border-box;
         align-items: center;
         justify-content: center;
-        box-sizing: border-box;
+        gap: 0.15rem;
         line-height: normal;
 
         &__content {
-            white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 
     .size-l {
-        font-size: 1.125rem;
         padding: 0.3rem 0.65rem;
+        font-size: 1.125rem;
 
         .mat-icon {
             font-size: 1.5rem;
@@ -33,8 +34,8 @@
     }
 
     .size-m {
-        font-size: 0.875rem;
         padding: 0.22rem 0.65rem;
+        font-size: 0.875rem;
 
         .mat-icon {
             font-size: 1.05rem;
@@ -42,8 +43,8 @@
     }
 
     .size-s {
-        font-size: 0.75rem;
         padding: 0.2rem 0.65rem;
+        font-size: 0.75rem;
         letter-spacing: 0.025rem;
 
         .mat-icon {
@@ -52,8 +53,8 @@
     }
 
     .mat-icon {
-        height: unset;
         width: unset;
+        height: unset;
     }
 
     .bold {

--- a/projects/ui-kit/src/lib/ui-kit/info-badge/stories/component/test-info-badge/test-info-badge.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/info-badge/stories/component/test-info-badge/test-info-badge.component.scss
@@ -4,8 +4,8 @@
     gap: 10px;
 
     &__container {
-        border: 1px grey dashed;
         max-width: 200px;
         padding: 5px;
+        border: 1px grey dashed;
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/info-badge/stories/directives/test-info-badge.directive.ts
+++ b/projects/ui-kit/src/lib/ui-kit/info-badge/stories/directives/test-info-badge.directive.ts
@@ -19,11 +19,11 @@ export class TestInfoBadgeDirective implements OnInit {
          * In project, you can use:
          *  if (this.#platformService.isPlatformBrowser) {
          *             this.infoBadgeColors = {
-         *                 success: this.#document.body.computedStyleMap().get('--clr-cell-success').toString(),
-         *                 info: this.#document.body.computedStyleMap().get('--clr-yellow').toString(),
-         *                 warning: this.#document.body.computedStyleMap().get('--clr-red-100').toString(),
-         *                 primary: this.#document.body.computedStyleMap().get('--clr-base-accent').toString(),
-         *                 disabled: this.#document.body.computedStyleMap().get('--clr-gray').toString(),
+         *                 success: this.#document.body.computedStyleMap().get('--rt-color-green-100').toString(),
+         *                 info: this.#document.body.computedStyleMap().get('--rt-color-blue-100').toString(),
+         *                 warning: this.#document.body.computedStyleMap().get('--rt-color-red-100').toString(),
+         *                 primary: this.#document.body.computedStyleMap().get('--rt-color-brand').toString(),
+         *                 disabled: this.#document.body.computedStyleMap().get('--rt-color-neutral-40').toString(),
          *             };
          *         }
          */

--- a/projects/ui-kit/src/lib/ui-kit/modal/modal.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/modal/modal.component.scss
@@ -47,23 +47,23 @@ $modal: (
     ::ng-deep {
         .--highlighted {
             display: inline;
-            font-weight: var(--rt-modal-text-highlited-font-weight);
             color: var(--rt-modal-text-highlited-color);
+            font-weight: var(--rt-modal-text-highlited-font-weight);
         }
 
         .--warn {
             display: inline;
+            color: var(--rt-modal-text-warn-color);
             font-size: var(--rt-modal-text-warn-font-size);
             font-weight: var(--rt-modal-text-warn-font-weight);
-            color: var(--rt-modal-text-warn-color);
         }
     }
 
     .rtui-modal {
         &__title {
             h1 {
-                font-size: var(--rt-modal-title-font-size);
                 color: var(--rt-modal-title-color);
+                font-size: var(--rt-modal-title-font-size);
                 font-weight: var(--rt-modal-title-font-weight);
             }
 
@@ -93,7 +93,7 @@ $modal: (
         height: auto;
     }
 
-    .mdc-dialog__title::before {
+    .mdc-dialog__title:before {
         height: 100%;
     }
 
@@ -101,8 +101,8 @@ $modal: (
         padding: var(--rt-modal-content-padding);
         color: var(--rt-modal-content-color);
         font-size: var(--rt-modal-content-font-size);
+        overflow-wrap: var(--rt-modal-content-word-wrap);
         text-align: var(--rt-modal-content-text-align);
-        word-wrap: var(--rt-modal-content-word-wrap);
 
         mat-form-field {
             width: 100%;

--- a/projects/ui-kit/src/lib/ui-kit/popover/rtui-popover-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/popover/rtui-popover-container.component.scss
@@ -4,7 +4,7 @@
     width: fit-content;
 
     /* Hack to show properly popover on mouse hover */
-    padding-top: 20px;
+    padding-top: var(--rt-spacing-20);
     text-align: left;
     transition:
         transform 0.1s,

--- a/projects/ui-kit/src/lib/ui-kit/popover/rtui-popover-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/popover/rtui-popover-container.component.scss
@@ -1,12 +1,11 @@
 :host {
     position: absolute;
-    width: fit-content;
     display: block;
+    width: fit-content;
 
     /* Hack to show properly popover on mouse hover */
     padding-top: 20px;
     text-align: left;
-
     transition:
         transform 0.1s,
         opacity 0.5s;

--- a/projects/ui-kit/src/lib/ui-kit/scrollable/scrollable-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/scrollable/scrollable-container.component.scss
@@ -27,12 +27,10 @@ $scrollable: (
 );
 
 :host {
-    height: var(--rt-scrollable-host-height);
-    width: var(--rt-scrollable-host-width);
-
     display: var(--rt-scrollable-host-display);
+    width: var(--rt-scrollable-host-width);
+    height: var(--rt-scrollable-host-height);
     flex-direction: var(--rt-scrollable-host-flex-direction);
-
     background-color: var(--rt-scrollable-host-background-color);
 
     @each $element, $elements in $scrollable {
@@ -49,11 +47,11 @@ $scrollable: (
 
         &__content {
             display: var(--rt-scrollable-content-display);
+            overflow: auto;
             flex-direction: var(--rt-scrollable-content-flex-direction);
             flex-grow: var(--rt-scrollable-content-flex-grow);
             padding: var(--rt-scrollable-content-padding);
             background-color: var(--rt-scrollable-content-background-color);
-            overflow: auto;
         }
 
         &__footer {

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.scss
@@ -2,12 +2,12 @@
     &::ng-deep {
         // Set expansion panel header padding
         .mat-expansion-indicator {
-            padding: 0 1.5rem;
+            padding: 0 var(--rt-spacing-24);
         }
 
         // Set expansion panel body padding
         .mat-expansion-panel-body {
-            padding: 0 0 0 1rem;
+            padding: 0 0 0 var(--rt-spacing-16);
         }
 
         // Set expansion panel transparent container
@@ -40,16 +40,16 @@
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                padding: 0.1rem;
+                padding: var(--rt-spacing-2);
                 border: 1.5px solid transparent;
-                border-radius: 50%;
-                margin-left: 0.5rem;
+                border-radius: var(--rt-radius-full);
+                margin-left: var(--rt-spacing-8);
                 cursor: pointer;
 
                 &__icon {
                     width: 1.25rem;
                     height: 1.25rem;
-                    font-size: 1.25rem;
+                    font-size: var(--rt-font-size-lg);
                 }
 
                 &:hover {
@@ -63,7 +63,7 @@
         padding: 0;
 
         // Set expand sub item header border like menu item border
-        border-radius: 1.35rem;
+        border-radius: var(--rt-radius-xl);
         box-shadow: none;
 
         &--fixed {

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.scss
@@ -2,7 +2,7 @@
     &::ng-deep {
         // Set expansion panel header padding
         .mat-expansion-indicator {
-            padding: 0 1.5rem 0 1.5rem;
+            padding: 0 1.5rem;
         }
 
         // Set expansion panel body padding
@@ -26,25 +26,25 @@
 
         .rtui-side-menu-sub-item-title {
             display: flex;
-            justify-content: space-between;
             align-items: center;
+            justify-content: space-between;
 
             &__text {
+                overflow: hidden;
                 font-size: var(--rt-side-menu-sub-menu-item-title-font-size);
                 text-overflow: ellipsis;
                 white-space: nowrap;
-                overflow: hidden;
             }
 
             .rtui-side-menu-sub-item-title-button {
                 display: flex;
-                justify-content: center;
                 align-items: center;
+                justify-content: center;
                 padding: 0.1rem;
-                margin-left: 0.5rem;
-                border-radius: 50%;
-                cursor: pointer;
                 border: 1.5px solid transparent;
+                border-radius: 50%;
+                margin-left: 0.5rem;
+                cursor: pointer;
 
                 &__icon {
                     width: 1.25rem;
@@ -61,9 +61,10 @@
 
     .rtui-side-menu-expand-sub-item {
         padding: 0;
-        box-shadow: none;
+
         // Set expand sub item header border like menu item border
         border-radius: 1.35rem;
+        box-shadow: none;
 
         &--fixed {
             min-width: var(--rt-side-menu-sub-menu-item-width);
@@ -78,9 +79,8 @@
             }
 
             &__icon {
-                margin-inline-start: var(--mat-list-list-item-leading-icon-start-space);
-                margin-inline-end: var(--mat-list-list-item-leading-icon-end-space);
                 color: var(--mdc-list-list-item-leading-icon-color);
+                margin-inline: var(--mat-list-list-item-leading-icon-start-space) var(--mat-list-list-item-leading-icon-end-space);
             }
 
             &__title {

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu-sub-item/rtui-side-menu-sub-item.component.ts
@@ -15,7 +15,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatListItem, MatListItemIcon, MatListItemTitle, MatNavList } from '@angular/material/list';
 import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltip } from '@angular/material/tooltip';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { RtHideTooltipDirective, RtIconOutlinedDirective } from '@rt-tools/utils';
 import { ISideMenu } from '../side-menu.types';
 import { RtuiSideMenuComponent } from '../menu/rtui-side-menu.component';
@@ -38,6 +38,7 @@ import { RtuiSideMenuComponent } from '../menu/rtui-side-menu.component';
         // directives
         BlockDirective,
         ElemDirective,
+        ModDirective,
         RtIconOutlinedDirective,
         RtHideTooltipDirective,
     ],

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.scss
@@ -41,21 +41,21 @@ $side-menu: (
 
         .rtui-mobile-side-menu-list {
             display: flex;
-            flex-direction: column;
             width: 100%;
+            flex-direction: column;
 
             &--scrollable {
                 width: fit-content;
             }
 
             &__sub {
+                animation: fade-in-animation 0.15s ease-in-out 0.15s forwards;
                 opacity: 0;
-                animation: fadeInAnimation 0.15s ease-in-out 0.15s forwards;
             }
 
             .rtui-mobile-side-menu-list-main {
+                animation: fade-in-animation 0.15s ease-in-out 0.15s forwards;
                 opacity: 0;
-                animation: fadeInAnimation 0.15s ease-in-out 0.15s forwards;
 
                 .rtui-mobile-side-menu-item {
                     &__icon {
@@ -66,22 +66,22 @@ $side-menu: (
 
                     .rtui-mobile-side-menu-item-title {
                         display: flex;
-                        justify-content: space-between;
                         align-items: center;
+                        justify-content: space-between;
 
                         &__text {
+                            overflow: hidden;
                             font-size: 0.75rem;
                             text-overflow: ellipsis;
                             white-space: nowrap;
-                            overflow: hidden;
                         }
 
                         .rtui-mobile-side-menu-item-title-button {
                             display: flex;
-                            justify-content: center;
                             align-items: center;
-                            margin-left: 0.5rem;
+                            justify-content: center;
                             border-radius: 50%;
+                            margin-left: 0.5rem;
 
                             &__icon {
                                 width: var(--rt-side-menu-mobile-item-additional-icon-size);
@@ -104,37 +104,37 @@ $side-menu: (
 
         &__list {
             display: flex;
+            width: 100%;
             flex-direction: column;
             align-items: center;
-            width: 100%;
 
             .rtui-side-menu-item {
                 display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
-                cursor: pointer;
                 width: 100%;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                cursor: pointer;
 
                 .rtui-side-menu-item-button {
-                    padding: 0;
                     display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    height: var(--rt-side-menu-item-height);
                     width: var(--rt-side-menu-item-width);
+                    height: var(--rt-side-menu-item-height);
+                    align-items: center;
+                    justify-content: center;
+                    padding: 0;
 
                     &__icon {
                         display: flex;
-                        justify-content: center;
                         align-items: center;
+                        justify-content: center;
                     }
                 }
 
                 &__title {
                     font-size: var(--rt-side-menu-item-font-size);
-                    text-align: var(--rt-side-menu-item-text-align);
                     line-height: var(--rt-side-menu-item-line-height);
+                    text-align: var(--rt-side-menu-item-text-align);
                 }
             }
 
@@ -161,14 +161,13 @@ $side-menu: (
             height: 100%;
             border-left: 1px solid var(--rt-border-neutral-default);
             box-shadow:
-                14px 0 28px rgba(0, 0, 0, 0.25),
-                10px 0 10px rgba(0, 0, 0, 0.22);
+                14px 0 28px rgb(0 0 0 / 25%),
+                10px 0 10px rgb(0 0 0 / 22%);
 
             &__list {
                 width: 100%;
-
+                animation: fade-in-animation 0.15s ease-in-out 0.15s forwards;
                 opacity: 0;
-                animation: fadeInAnimation 0.15s ease-in-out 0.15s forwards;
 
                 &--scrollable {
                     min-width: fit-content;
@@ -178,7 +177,7 @@ $side-menu: (
     }
 }
 
-@keyframes fadeInAnimation {
+@keyframes fade-in-animation {
     to {
         opacity: 1;
     }

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.scss
@@ -71,7 +71,7 @@ $side-menu: (
 
                         &__text {
                             overflow: hidden;
-                            font-size: 0.75rem;
+                            font-size: var(--rt-font-size-xs);
                             text-overflow: ellipsis;
                             white-space: nowrap;
                         }
@@ -80,8 +80,8 @@ $side-menu: (
                             display: flex;
                             align-items: center;
                             justify-content: center;
-                            border-radius: 50%;
-                            margin-left: 0.5rem;
+                            border-radius: var(--rt-radius-full);
+                            margin-left: var(--rt-spacing-8);
 
                             &__icon {
                                 width: var(--rt-side-menu-mobile-item-additional-icon-size);
@@ -93,7 +93,7 @@ $side-menu: (
                 }
 
                 .rtui-mobile-side-menu-item + .rtui-mobile-side-menu-item {
-                    margin-top: 0.5rem;
+                    margin-top: var(--rt-spacing-8);
                 }
             }
         }
@@ -157,12 +157,13 @@ $side-menu: (
         }
 
         .rtui-sub-side-menu-content {
+            // Component-local elevation token for the slide-out sub-menu drawer.
+            --rt-side-menu-sub-content-shadow: 14px 0 28px rgb(0 0 0 / 25%), 10px 0 10px rgb(0 0 0 / 22%);
+
             width: var(--rt-side-menu-sub-menu-width);
             height: 100%;
             border-left: 1px solid var(--rt-border-neutral-default);
-            box-shadow:
-                14px 0 28px rgb(0 0 0 / 25%),
-                10px 0 10px rgb(0 0 0 / 22%);
+            box-shadow: var(--rt-side-menu-sub-content-shadow);
 
             &__list {
                 width: 100%;

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/menu/rtui-side-menu.component.ts
@@ -22,7 +22,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatListItem, MatListItemIcon, MatNavList } from '@angular/material/list';
 import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { RtIconOutlinedDirective, RtNavigationDirective, RtScrollToElementDirective, transformArrayInput } from '@rt-tools/utils';
 import { ISideMenu } from '../side-menu.types';
 import {
@@ -59,6 +59,7 @@ export class RtuiSideMenuFooterDirective {}
         // directives
         BlockDirective,
         ElemDirective,
+        ModDirective,
         RtuiScrollableContainerHeaderDirective,
         RtuiScrollableContainerContentDirective,
         RtuiScrollableContainerFooterDirective,

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/stories/component/test-side-menu-wrapper.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/stories/component/test-side-menu-wrapper.component.scss
@@ -23,7 +23,7 @@
             align-items: center;
             justify-content: center;
             padding: 0.5rem 0 1rem;
-            border-bottom: 1px solid var(--clr-black-20);
+            border-bottom: 1px solid var(--rt-color-neutral-25);
             cursor: pointer;
         }
 
@@ -34,7 +34,7 @@
             align-items: center;
             justify-content: center;
             padding-top: 0.5rem;
-            border-top: 1px solid var(--clr-black-20);
+            border-top: 1px solid var(--rt-color-neutral-25);
             gap: 0.5rem;
 
             &__icon {

--- a/projects/ui-kit/src/lib/ui-kit/side-menu/stories/component/test-side-menu-wrapper.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/side-menu/stories/component/test-side-menu-wrapper.component.scss
@@ -13,35 +13,35 @@
     height: 100vh;
     margin: -1rem;
     box-shadow:
-        0 14px 28px rgba(0, 0, 0, 0.25),
-        0 10px 10px rgba(0, 0, 0, 0.22);
+        0 14px 28px rgb(0 0 0 / 25%),
+        0 10px 10px rgb(0 0 0 / 22%);
 
     .side-menu-wrapper {
         &__header {
             display: flex;
+            width: 100%;
             align-items: center;
             justify-content: center;
-            width: 100%;
-            padding: 0.5rem 0 1rem 0;
-            cursor: pointer;
+            padding: 0.5rem 0 1rem;
             border-bottom: 1px solid var(--clr-black-20);
+            cursor: pointer;
         }
 
         .footer {
             display: flex;
+            width: 100%;
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            width: 100%;
-            gap: 0.5rem;
             padding-top: 0.5rem;
             border-top: 1px solid var(--clr-black-20);
+            gap: 0.5rem;
 
             &__icon {
-                height: 2rem;
                 width: 2rem;
-                font-size: 2rem;
+                height: 2rem;
                 cursor: pointer;
+                font-size: 2rem;
             }
         }
     }

--- a/projects/ui-kit/src/lib/ui-kit/snack-bar/snack-bar.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/snack-bar/snack-bar.component.scss
@@ -26,9 +26,9 @@ $snack-bar: (
 );
 
 :host {
-    height: 100%;
-    width: 100%;
     display: flex;
+    width: 100%;
+    height: 100%;
     align-items: center;
     justify-content: space-between;
 
@@ -40,10 +40,10 @@ $snack-bar: (
 
     .rt-snack-bar {
         &__content {
-            height: 100%;
-            width: 100%;
             position: relative;
             display: flex;
+            width: 100%;
+            height: 100%;
             align-items: center;
             gap: var(--rt-snack-bar-content-gap);
 
@@ -56,16 +56,16 @@ $snack-bar: (
                 width: var(--rt-snack-bar-icon-size);
                 min-width: var(--rt-snack-bar-icon-size);
                 height: var(--rt-snack-bar-icon-size);
-                font-size: var(--rt-snack-bar-icon-size);
                 color: var(--rt-snack-bar-icon-color);
+                font-size: var(--rt-snack-bar-icon-size);
             }
 
             &-message {
                 display: -webkit-box;
                 overflow: hidden;
-                text-overflow: ellipsis;
-                -webkit-line-clamp: var(--rt-snack-bar-message-line-clamp);
                 -webkit-box-orient: vertical;
+                -webkit-line-clamp: var(--rt-snack-bar-message-line-clamp);
+                text-overflow: ellipsis;
             }
         }
 
@@ -87,11 +87,11 @@ $snack-bar: (
 
         &__progress {
             position: absolute;
+            right: 0;
             bottom: 0;
             left: 0;
-            right: 0;
-            height: var(--rt-snack-bar-progress-height);
             width: 100%;
+            height: var(--rt-snack-bar-progress-height);
             background-color: var(--mat-button-filled-container-color);
             border-bottom-left-radius: var(--mat-snack-bar-container-shape);
             border-bottom-right-radius: var(--mat-snack-bar-container-shape);

--- a/projects/ui-kit/src/lib/ui-kit/snack-bar/stories/component/test-snack-bar.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/snack-bar/stories/component/test-snack-bar.component.scss
@@ -1,7 +1,7 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
     margin: -1rem;
 
@@ -10,10 +10,10 @@
     }
 
     .content {
-        flex-grow: 1;
         display: flex;
-        justify-content: center;
+        flex-grow: 1;
         align-items: flex-start;
+        justify-content: center;
     }
 
     .action {

--- a/projects/ui-kit/src/lib/ui-kit/spinner/spinner.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/spinner/spinner.component.scss
@@ -32,13 +32,14 @@
             }
 
             &--bgr-color {
+                // Component-local elevation token for the spinner's circular backdrop.
+                --rt-spinner-backdrop-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+
                 width: 3rem;
                 height: 3rem;
-                border-radius: 50%;
+                border-radius: var(--rt-radius-full);
                 background: var(--rt-bg-base-base);
-                box-shadow:
-                    0 1px 3px rgb(0 0 0 / 12%),
-                    0 1px 2px rgb(0 0 0 / 24%);
+                box-shadow: var(--rt-spinner-backdrop-shadow);
             }
         }
     }

--- a/projects/ui-kit/src/lib/ui-kit/spinner/spinner.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/spinner/spinner.component.scss
@@ -1,25 +1,22 @@
 :host {
-    z-index: 10000;
     position: absolute;
-
+    z-index: 10000;
+    display: flex;
     width: 100%;
     height: 100%;
-
-    display: flex;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 
     .c-spinner {
         &__container {
+            display: flex;
             width: 100%;
             height: 100%;
-
-            display: flex;
             align-items: center;
             justify-content: center;
 
             &--bgr-color {
-                background-color: rgba(#f5f6f8, 0.85);
+                background-color: color-mix(in srgb, var(--rt-bg-base-subtle) 85%, transparent);
             }
         }
 
@@ -37,12 +34,11 @@
             &--bgr-color {
                 width: 3rem;
                 height: 3rem;
-
-                background: var(--rt-bg-base-base);
                 border-radius: 50%;
+                background: var(--rt-bg-base-base);
                 box-shadow:
-                    0 1px 3px rgba(0, 0, 0, 0.12),
-                    0 1px 2px rgba(0, 0, 0, 0.24);
+                    0 1px 3px rgb(0 0 0 / 12%),
+                    0 1px 2px rgb(0 0 0 / 24%);
             }
         }
     }

--- a/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.scss
@@ -24,23 +24,23 @@ $clear-button: (
 
     .rtui-clear-button {
         display: flex;
-        justify-content: center;
         align-items: center;
+        justify-content: center;
+        padding: var(--rt-clear-button-host-padding);
         border: none;
         border-radius: 50%;
         margin: var(--rt-clear-button-host-margin);
-        padding: var(--rt-clear-button-host-padding);
         background-color: var(--rt-clear-button-host-background-color);
 
         &--invisible {
-            @include mixins.visually-hidden();
+            @include mixins.visually-hidden;
         }
 
         &__icon {
             width: var(--rt-clear-button-icon-size);
             height: var(--rt-clear-button-icon-size);
-            font-size: var(--rt-clear-button-icon-size);
             color: var(--rt-clear-button-icon-color);
+            font-size: var(--rt-clear-button-icon-size);
 
             &:hover {
                 color: var(--rt-clear-button-icon-hover-color);

--- a/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.scss
@@ -28,7 +28,7 @@ $clear-button: (
         justify-content: center;
         padding: var(--rt-clear-button-host-padding);
         border: none;
-        border-radius: 50%;
+        border-radius: var(--rt-radius-full);
         margin: var(--rt-clear-button-host-margin);
         background-color: var(--rt-clear-button-host-background-color);
 

--- a/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/clear-search-button/rtui-clear-button.component.ts
@@ -12,7 +12,7 @@ import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip, TooltipPosition } from '@angular/material/tooltip';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { isString } from '@rt-tools/utils';
 
 @Component({
@@ -29,6 +29,7 @@ import { isString } from '@rt-tools/utils';
         // BEM
         BlockDirective,
         ElemDirective,
+        ModDirective,
     ],
 })
 export class RtuiClearButtonComponent {

--- a/projects/ui-kit/src/lib/ui-kit/table/components/pagination-view/rtui-pagination.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/pagination-view/rtui-pagination.component.scss
@@ -48,9 +48,9 @@ $pagination: (
 );
 
 :host {
+    display: flex;
     width: fit-content;
     height: 100%;
-    display: flex;
 
     @each $element, $elements in $pagination {
         @each $style-token, $value in $elements {
@@ -60,21 +60,19 @@ $pagination: (
 
     .pagination-container {
         position: relative;
-
         display: flex;
-        justify-content: flex-start;
         align-items: center;
-        gap: var(--rt-table-pagination-container-gap);
-
+        justify-content: flex-start;
         color: var(--rt-table-pagination-container-color);
         font-size: var(--rt-table-pagination-container-font-size);
         font-weight: var(--rt-table-pagination-container-font-weight);
+        gap: var(--rt-table-pagination-container-gap);
         line-height: var(--rt-table-pagination-container-line-height);
 
         &--clipped {
             flex-direction: column;
-            justify-content: center;
             align-items: flex-start;
+            justify-content: center;
             gap: var(--rt-table-pagination-container-mobile-gap);
         }
 
@@ -85,26 +83,23 @@ $pagination: (
 
         .paging {
             display: flex;
-            justify-content: center;
             align-items: center;
-            gap: var(--rt-table-pagination-paging-gap);
+            justify-content: center;
             margin: var(--rt-table-pagination-container-margin);
+            gap: var(--rt-table-pagination-paging-gap);
 
             &--clipped {
                 margin: var(--rt-table-pagination-paging-mobile-margin);
             }
 
             &__item {
-                display: flex;
-                justify-content: center;
-                align-items: center;
-
                 position: relative;
-
+                display: flex;
+                align-items: center;
+                justify-content: center;
                 padding: var(--rt-table-pagination-paging-item-padding);
                 border: var(--rt-table-pagination-paging-item-border);
                 border-radius: var(--rt-table-pagination-paging-item-border-radius);
-
                 background-color: transparent;
                 cursor: default;
                 pointer-events: none;
@@ -119,13 +114,13 @@ $pagination: (
                 }
 
                 &:hover:not(.divider) {
-                    color: var(--rt-table-pagination-paging-item-hover-color);
                     background-color: var(--rt-table-pagination-paging-item-hover-background-color);
+                    color: var(--rt-table-pagination-paging-item-hover-color);
                 }
 
                 &--active {
-                    color: var(--rt-table-pagination-paging-item-active-color);
                     background-color: var(--rt-table-pagination-paging-item-active-background-color);
+                    color: var(--rt-table-pagination-paging-item-active-color);
                 }
 
                 &--enabled {
@@ -138,9 +133,9 @@ $pagination: (
                 }
 
                 &--divider {
+                    border: none;
                     cursor: default;
                     pointer-events: none;
-                    border: none;
                 }
             }
         }
@@ -148,10 +143,10 @@ $pagination: (
         .page-size-toggle {
             display: flex;
             flex-direction: row;
-            justify-content: center;
             align-items: center;
-            gap: var(--rt-table-pagination-size-toggle-gap);
+            justify-content: center;
             margin: var(--rt-table-pagination-container-margin);
+            gap: var(--rt-table-pagination-size-toggle-gap);
 
             &--clipped {
                 margin: var(--rt-table-pagination-size-toggle-selector-mobile-margin);
@@ -165,14 +160,11 @@ $pagination: (
                 width: auto;
                 min-width: var(--rt-table-pagination-size-toggle-selector-min-width);
                 height: var(--rt-table-pagination-size-toggle-selector-height);
-
                 border: var(--rt-table-pagination-paging-item-border);
                 border-radius: var(--rt-table-pagination-paging-item-border-radius);
-
                 background-color: transparent;
-                cursor: pointer;
-
                 color: var(--rt-table-pagination-container-color);
+                cursor: pointer;
                 font-size: var(--rt-table-pagination-container-font-size);
                 font-weight: var(--rt-table-pagination-container-font-weight);
                 line-height: var(--rt-table-pagination-container-line-height);

--- a/projects/ui-kit/src/lib/ui-kit/table/components/pagination-view/rtui-pagination.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/pagination-view/rtui-pagination.component.ts
@@ -24,7 +24,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 
-import { BlockDirective, ElemDirective, Nullable, WINDOW } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable, WINDOW } from '@rt-tools/core';
 import { isNumber, PageModel } from '@rt-tools/utils';
 import { DEFAULT_PAGE_SIZE } from '../../util/default-pagination';
 
@@ -33,7 +33,7 @@ import { DEFAULT_PAGE_SIZE } from '../../util/default-pagination';
     templateUrl: './rtui-pagination.component.html',
     styleUrls: ['./rtui-pagination.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [ReactiveFormsModule, BlockDirective, ElemDirective],
+    imports: [ReactiveFormsModule, BlockDirective, ElemDirective, ModDirective],
 })
 export class RtuiPaginationComponent implements OnInit, AfterViewInit {
     readonly #injector: Injector = inject(Injector);

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-base-cell/table-base-cell.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-base-cell/table-base-cell.component.scss
@@ -26,14 +26,12 @@ $base-cell: (
 );
 
 :host {
-    height: 100%;
-    width: 100%;
-
+    position: relative;
     display: flex;
+    width: 100%;
+    height: 100%;
     align-items: center;
     gap: var(--rt-table-base-cell-host-gap);
-
-    position: relative;
 
     @each $element, $elements in $base-cell {
         @each $style-token, $value in $elements {
@@ -49,16 +47,16 @@ $base-cell: (
         }
 
         &__title {
-            width: 100%;
             display: table;
+            width: 100%;
             table-layout: fixed;
 
             &-text {
+                overflow: hidden;
                 width: 100%;
                 padding: var(--rt-table-base-cell-title-padding);
-                white-space: nowrap;
-                overflow: hidden;
                 text-overflow: ellipsis;
+                white-space: nowrap;
             }
 
             &--align {
@@ -90,14 +88,15 @@ $base-cell: (
 
         &__copy-button {
             position: absolute;
-            visibility: hidden;
             padding: var(--rt-table-base-cell-copy-button-padding);
             background-color: var(--rt-table-base-cell-copy-button-background-color);
+            visibility: hidden;
 
             &--position {
                 &--left {
                     left: var(--rt-table-base-cell-copy-button-position-left);
                 }
+
                 &--right {
                     right: var(--rt-table-base-cell-copy-button-position-right);
                 }

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-config-aside/rt-table-config-aside.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-config-aside/rt-table-config-aside.component.scss
@@ -1,4 +1,4 @@
 :host {
-    height: 100%;
     width: 100%;
+    height: 100%;
 }

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-container/table-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-container/table-container.component.scss
@@ -44,24 +44,26 @@ $table-container: (
 );
 
 :host {
-    width: 100%;
     position: relative;
     display: flex;
     overflow: hidden;
+    width: 100%;
 
     // initial table container scrollbar styles
     ::-webkit-scrollbar-track:hover {
         border: 1px solid var(--rt-border-neutral-subtle);
     }
+
     ::-webkit-scrollbar-thumb {
-        background: var(--rt-scrollbar-thumb);
         border: 3px solid transparent;
         border-radius: 6px;
+        background: var(--rt-scrollbar-thumb);
         background-clip: content-box;
     }
+
     ::-webkit-scrollbar-thumb:hover {
-        background: var(--rt-scrollbar-thumb-hover);
         border: 2px solid transparent;
+        background: var(--rt-scrollbar-thumb-hover);
         background-clip: content-box;
     }
 
@@ -94,10 +96,10 @@ $table-container: (
     .table-container {
         &__selectors {
             display: flex;
-            justify-content: flex-start;
-            align-items: center;
-            flex-grow: 1;
             width: 100%;
+            flex-grow: 1;
+            align-items: center;
+            justify-content: flex-start;
             margin: var(--rt-table-container-selectors-margin);
             gap: var(--rt-table-container-toolbar-actions-gap);
 
@@ -110,16 +112,16 @@ $table-container: (
             }
 
             &-counter {
-                font-size: var(--rt-table-container-selector-counter-font-size);
                 color: var(--rt-table-container-selector-counter-color);
+                font-size: var(--rt-table-container-selector-counter-font-size);
             }
         }
 
         &__toolbar {
-            width: 100%;
             display: flex;
-            justify-content: flex-end;
+            width: 100%;
             align-items: center;
+            justify-content: flex-end;
 
             &-actions {
                 display: flex;
@@ -143,9 +145,9 @@ $table-container: (
         }
 
         &__content {
+            overflow: auto;
             width: 100%;
             flex-grow: 1;
-            overflow: auto;
             padding: var(--rt-table-container-content-padding);
 
             &::-webkit-scrollbar {
@@ -155,12 +157,12 @@ $table-container: (
         }
 
         &__placeholder {
+            display: flex;
             width: var(--rt-table-container-placeholder-width);
             height: var(--rt-table-container-placeholder-height);
-            display: flex;
             flex-direction: column;
-            justify-content: center;
             align-items: center;
+            justify-content: center;
             gap: var(--rt-table-container-placeholder-gap);
 
             &-icon {
@@ -203,8 +205,8 @@ $table-container: (
 
                 &-search {
                     width: 100%;
-                    grid-row: 1;
                     justify-content: center;
+                    grid-row: 1;
                 }
             }
         }

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-container/table-container.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-container/table-container.component.scss
@@ -56,7 +56,7 @@ $table-container: (
 
     ::-webkit-scrollbar-thumb {
         border: 3px solid transparent;
-        border-radius: 6px;
+        border-radius: var(--rt-radius-sm);
         background: var(--rt-scrollbar-thumb);
         background-clip: content-box;
     }

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-header-cell/table-header-cell.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-header-cell/table-header-cell.component.scss
@@ -21,8 +21,8 @@ $header-cell: (
 
 :host {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
     cursor: pointer;
 
     @each $element, $elements in $header-cell {
@@ -38,8 +38,8 @@ $header-cell: (
     }
 
     .header-cell-label {
-        flex-grow: 1;
         display: flex;
+        flex-grow: 1;
         align-items: center;
         gap: var(--rt-table-header-cell-label-gap);
 
@@ -64,9 +64,9 @@ $header-cell: (
         }
 
         &__text {
-            white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         &__suffix {
@@ -85,10 +85,9 @@ $header-cell: (
     .header-cell-icons {
         display: flex;
         flex-direction: column;
-        justify-content: center;
         align-items: center;
+        justify-content: center;
         margin: var(--rt-table-header-cell-icon-margin);
-
         visibility: hidden;
 
         &--active {
@@ -98,9 +97,9 @@ $header-cell: (
         &__icon {
             width: 0;
             height: 0;
-            border-left: 3px solid transparent;
             border-right: 3px solid transparent;
             border-bottom: 5.2px solid var(--rt-table-header-cell-icon-color);
+            border-left: 3px solid transparent;
 
             &--second {
                 margin-top: 2px;

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-header-cell/table-header-cell.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-header-cell/table-header-cell.component.scss
@@ -102,7 +102,7 @@ $header-cell: (
             border-left: 3px solid transparent;
 
             &--second {
-                margin-top: 2px;
+                margin-top: var(--rt-spacing-2);
                 transform: scaleY(-1);
             }
 

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-header-filter-cell/table-header-filter-cell.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-header-filter-cell/table-header-filter-cell.component.scss
@@ -3,7 +3,7 @@
     width: 100%;
     align-items: center;
     justify-content: flex-start;
-    gap: 0.5rem;
+    gap: var(--rt-spacing-8);
 
     .table-header-cell-filter-input {
         width: 100%;

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table-header-filter-cell/table-header-filter-cell.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table-header-filter-cell/table-header-filter-cell.component.scss
@@ -1,8 +1,8 @@
 :host {
-    width: 100%;
     display: flex;
-    justify-content: flex-start;
+    width: 100%;
     align-items: center;
+    justify-content: flex-start;
     gap: 0.5rem;
 
     .table-header-cell-filter-input {

--- a/projects/ui-kit/src/lib/ui-kit/table/components/table/rtui-table.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/table/components/table/rtui-table.component.ts
@@ -27,7 +27,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatMenu, MatMenuTrigger } from '@angular/material/menu';
 import { MatRadioButton } from '@angular/material/radio';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { FILTER_OPERATOR_TYPE_ENUM, FilterModel, RtIconOutlinedDirective, SortModel, transformArrayInput } from '@rt-tools/utils';
 import { IRtuiTable, ITable, RTUI_TABLE_COMPONENT_TOKEN, RtTableConfigService, TABLE_COLUMN_TYPES_ENUM } from '../../util';
 import { TableBaseCellComponent } from '../table-base-cell/table-base-cell.component';
@@ -84,6 +84,7 @@ export class RtuiTableAdditionalRowActionsDirective {}
         // directives
         BlockDirective,
         ElemDirective,
+        ModDirective,
         RtIconOutlinedDirective,
         RtuiTableRowClickDirective,
 

--- a/projects/ui-kit/src/lib/ui-kit/table/dynamic-list.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/dynamic-list.component.scss
@@ -1,6 +1,6 @@
 :host {
-    width: 100%;
-    height: 100%;
     display: flex;
     overflow: hidden;
+    width: 100%;
+    height: 100%;
 }

--- a/projects/ui-kit/src/lib/ui-kit/table/stories/dynamic-list/test-dynamic-list.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/stories/dynamic-list/test-dynamic-list.component.scss
@@ -1,7 +1,7 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
     margin: -1rem;
 

--- a/projects/ui-kit/src/lib/ui-kit/table/stories/pagination/test-pagination-component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/stories/pagination/test-pagination-component.scss
@@ -1,16 +1,16 @@
 :host {
+    position: relative;
+    display: flex;
+    overflow: hidden;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
     margin: -1rem;
-    position: relative;
-    overflow: hidden;
 
     .pagination {
-        width: 100%;
         position: absolute;
         top: 0;
         left: 0;
+        width: 100%;
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/table/stories/table/test-table-component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/table/stories/table/test-table-component.scss
@@ -1,7 +1,7 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
     margin: -1rem;
 }

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.spec.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.spec.ts
@@ -144,5 +144,14 @@ describe('RtThemeService', () => {
 
             expect(declarationSet(jsBlock)).toEqual(declarationSet(sassBlock));
         });
+
+        it('validates its input like the Sass mixin (parity)', () => {
+            const service: RtThemeService = setup();
+
+            expect(() => service.registerColorScheme('x', { bogus: { 100: '#000' } } as RtColorSchemeRamp)).toThrow(/unknown role/i);
+            expect(() => service.registerColorScheme('x', { primary: { 150: '#000' } })).toThrow(/integer 0–100/i);
+            expect(() => service.registerColorScheme('', teal)).toThrow(/non-empty string/i);
+            expect(() => service.registerColorScheme('default', teal)).toThrow(/non-empty string/i);
+        });
     });
 });

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.spec.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.spec.ts
@@ -1,0 +1,148 @@
+import { DOCUMENT } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import * as path from 'path';
+import * as sass from 'sass';
+
+import { RtThemeService } from './rtui-theme.service';
+import { RT_COLOR_SCHEME_STORAGE_KEY, RT_DARK_CLASS, RT_SCHEME_ATTRIBUTE, RtColorSchemeRamp } from './rtui-theme.types';
+
+const STYLES_DIR: string = path.join(__dirname, '../../../styles');
+
+/** Sorted `name:value` pairs (whitespace-insensitive) of custom-property declarations in a CSS block. */
+function declarationSet(css: string): string[] {
+    const out: string[] = [];
+    const re: RegExp = /(--rt-color-[\w-]+):\s*([^;]+);/g;
+    let match: RegExpExecArray | null = re.exec(css);
+
+    while (match !== null) {
+        out.push(`${match[1]}:${match[2].trim()}`);
+        match = re.exec(css);
+    }
+
+    return out.sort();
+}
+
+describe('RtThemeService', () => {
+    let document: Document;
+
+    beforeEach(() => {
+        window.localStorage.clear();
+        TestBed.configureTestingModule({});
+    });
+
+    afterEach(() => {
+        window.localStorage.clear();
+        document?.documentElement.removeAttribute(RT_SCHEME_ATTRIBUTE);
+        document?.documentElement.classList.remove(RT_DARK_CLASS);
+    });
+
+    function setup(): RtThemeService {
+        const service: RtThemeService = TestBed.inject(RtThemeService);
+        document = TestBed.inject(DOCUMENT);
+        TestBed.tick();
+
+        return service;
+    }
+
+    describe('color scheme — runtime', () => {
+        it('sets data-rt-scheme on <html> and persists the name', () => {
+            const service: RtThemeService = setup();
+
+            service.setColorScheme('teal');
+            TestBed.tick();
+
+            expect(service.colorScheme()).toBe('teal');
+            expect(document.documentElement.getAttribute(RT_SCHEME_ATTRIBUTE)).toBe('teal');
+            expect(window.localStorage.getItem(RT_COLOR_SCHEME_STORAGE_KEY)).toBe('teal');
+        });
+
+        it('clears the scheme on null and removes the attribute + storage key', () => {
+            const service: RtThemeService = setup();
+            service.setColorScheme('teal');
+            TestBed.tick();
+
+            service.setColorScheme(null);
+            TestBed.tick();
+
+            expect(service.colorScheme()).toBeNull();
+            expect(document.documentElement.hasAttribute(RT_SCHEME_ATTRIBUTE)).toBe(false);
+            expect(window.localStorage.getItem(RT_COLOR_SCHEME_STORAGE_KEY)).toBeNull();
+        });
+
+        it('treats \'default\' as a cleared scheme', () => {
+            const service: RtThemeService = setup();
+
+            service.setColorScheme('default');
+            TestBed.tick();
+
+            expect(service.colorScheme()).toBeNull();
+            expect(document.documentElement.hasAttribute(RT_SCHEME_ATTRIBUTE)).toBe(false);
+        });
+
+        it('restores a persisted scheme on construction', () => {
+            window.localStorage.setItem(RT_COLOR_SCHEME_STORAGE_KEY, 'teal');
+
+            const service: RtThemeService = setup();
+
+            expect(service.colorScheme()).toBe('teal');
+            expect(document.documentElement.getAttribute(RT_SCHEME_ATTRIBUTE)).toBe('teal');
+        });
+
+        it('is orthogonal to the light/dark theme', () => {
+            const service: RtThemeService = setup();
+
+            service.setColorScheme('teal');
+            service.setTheme('dark');
+            TestBed.tick();
+
+            expect(document.documentElement.getAttribute(RT_SCHEME_ATTRIBUTE)).toBe('teal');
+            expect(document.documentElement.classList.contains(RT_DARK_CLASS)).toBe(true);
+        });
+    });
+
+    describe('registerColorScheme', () => {
+        const teal: RtColorSchemeRamp = {
+            primary: { 20: '#b3e3e1', 40: '#5cb8b5', 60: '#1a9d99', 100: '#008582' },
+            brand: { 20: '#e8e8e8', 100: '#008582' },
+        };
+
+        it('injects a <style> with the scoped [data-rt-scheme] block', () => {
+            const service: RtThemeService = setup();
+
+            service.registerColorScheme('teal', teal);
+
+            const style: HTMLElement | null = document.getElementById('rt-color-scheme-teal');
+            expect(style).not.toBeNull();
+            expect(style!.textContent).toContain(`[${RT_SCHEME_ATTRIBUTE}="teal"]`);
+            expect(style!.textContent).toContain('--rt-color-primary-100:#008582');
+        });
+
+        it('replaces an existing scheme style instead of duplicating it', () => {
+            const service: RtThemeService = setup();
+
+            service.registerColorScheme('teal', teal);
+            service.registerColorScheme('teal', { primary: { 100: '#006a67' } });
+
+            const styles: NodeListOf<Element> = document.querySelectorAll('#rt-color-scheme-teal');
+            expect(styles.length).toBe(1);
+            expect(styles[0].textContent).toContain('--rt-color-primary-100:#006a67');
+        });
+
+        it('produces declarations identical to the rt.color-scheme Sass mixin (parity)', () => {
+            const service: RtThemeService = setup();
+            service.registerColorScheme('teal', teal);
+
+            const jsBlock: string = document.getElementById('rt-color-scheme-teal')!.textContent ?? '';
+            const sassCss: string = sass.compileString(
+                '@use \'main\' as rt;\n@include rt.color-scheme(\'teal\', (' +
+                    'primary: (20: #b3e3e1, 40: #5cb8b5, 60: #1a9d99, 100: #008582),' +
+                    'brand: (20: #e8e8e8, 100: #008582)));',
+                { loadPaths: [STYLES_DIR] }
+            ).css;
+            // isolate the scheme block — the full compile also emits the default :root role rows
+            const sassBlock: string = sassCss.slice(sassCss.indexOf('[data-rt-scheme=teal]'));
+
+            expect(declarationSet(jsBlock)).toEqual(declarationSet(sassBlock));
+        });
+    });
+});

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
@@ -4,6 +4,7 @@ import { effect, inject, Injectable, Signal, signal, WritableSignal } from '@ang
 import { LOCAL_STORAGE, PlatformService } from '@rt-tools/core';
 
 import {
+    RT_ACCENT_ROLE_ENUM,
     RT_COLOR_SCHEME_STORAGE_KEY,
     RT_DARK_CLASS,
     RT_DEFAULT_SCHEME,
@@ -89,6 +90,8 @@ export class RtThemeService {
      * scheme — call {@link setColorScheme} afterwards.
      */
     public registerColorScheme(name: string, ramp: RtColorSchemeRamp): void {
+        this.#validateRamp(name, ramp);
+
         if (!this.#platformService.isPlatformBrowser) {
             return;
         }
@@ -150,7 +153,34 @@ export class RtThemeService {
         }
     }
 
-    /** Builds the `[data-rt-scheme="<name>"] { --rt-color-{role}-{N}: … }` block (mirrors the Sass mixin). */
+    /**
+     * Validates a ramp the same way the `rt.color-scheme` Sass mixin does — unknown
+     * role or out-of-range tone (must be an integer 0–100) throws. Keeps the JS twin
+     * at parity with the build-time generator instead of silently emitting bad rows.
+     */
+    #validateRamp(name: string, ramp: RtColorSchemeRamp): void {
+        if (!name || name === RT_DEFAULT_SCHEME) {
+            throw new Error(`registerColorScheme: name must be a non-empty string other than '${RT_DEFAULT_SCHEME}'.`);
+        }
+
+        const roles: string[] = Object.values(RT_ACCENT_ROLE_ENUM);
+
+        for (const role of Object.keys(ramp)) {
+            if (!roles.includes(role)) {
+                throw new Error(`registerColorScheme("${name}"): unknown role "${role}". Allowed roles: ${roles.join(', ')}.`);
+            }
+
+            for (const tone of Object.keys(ramp[role as RT_ACCENT_ROLE_ENUM] ?? {})) {
+                const step: number = Number(tone);
+
+                if (!Number.isInteger(step) || step < 0 || step > 100) {
+                    throw new Error(`registerColorScheme("${name}"): role "${role}" tone "${tone}" must be an integer 0–100.`);
+                }
+            }
+        }
+    }
+
+    /** Builds the `:root[data-rt-scheme="<name>"] { --rt-color-{role}-{N}: … }` block (mirrors the Sass mixin). */
     #buildSchemeCss(name: string, ramp: RtColorSchemeRamp): string {
         const declarations: string = Object.entries(ramp)
             .flatMap(([role, tones]: [string, Record<number, string> | undefined]): string[] =>
@@ -158,7 +188,7 @@ export class RtThemeService {
             )
             .join('');
 
-        return `[${RT_SCHEME_ATTRIBUTE}="${name}"]{${declarations}}`;
+        return `:root[${RT_SCHEME_ATTRIBUTE}="${name}"]{${declarations}}`;
     }
 
     #isDarkApplied(): boolean {

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
@@ -3,16 +3,31 @@ import { effect, inject, Injectable, Signal, signal, WritableSignal } from '@ang
 
 import { LOCAL_STORAGE, PlatformService } from '@rt-tools/core';
 
-import { RT_DARK_CLASS, RT_THEME_AUTO_CLASS, RT_THEME_ENUM, RT_THEME_STORAGE_KEY, RtThemeType } from './rtui-theme.types';
+import {
+    RT_COLOR_SCHEME_STORAGE_KEY,
+    RT_DARK_CLASS,
+    RT_DEFAULT_SCHEME,
+    RT_SCHEME_ATTRIBUTE,
+    RT_THEME_AUTO_CLASS,
+    RT_THEME_ENUM,
+    RT_THEME_STORAGE_KEY,
+    RtColorSchemeRamp,
+    RtThemeType,
+} from './rtui-theme.types';
 
 /**
- * Global theme switcher for the rt-tools design tokens.
+ * Global theme + color-scheme switcher for the rt-tools design tokens.
  *
- * Applies `.rt-dark` / `.rt-theme-auto` to `<html>`; all semantic tokens
- * (`--rt-*`) adapt through `color-scheme` + `light-dark()`.
- * The chosen theme is persisted to localStorage (`rt-theme` key).
+ * **Theme** (`light`/`dark`/`auto`): applies `.rt-dark` / `.rt-theme-auto` to
+ * `<html>`; semantic tokens (`--rt-*`) adapt through `color-scheme` + `light-dark()`.
+ * Persisted to localStorage (`rt-theme`). `auto` follows the OS preference.
  *
- * `auto` follows the OS preference (`prefers-color-scheme`).
+ * **Color scheme** (brand palette): toggles `data-rt-scheme="<name>"` on `<html>`,
+ * which activates a `[data-rt-scheme]` block (emitted by the `rt.color-scheme` Sass
+ * mixin or injected at runtime via {@link registerColorScheme}). It overrides only
+ * the accent-role rows `--rt-color-{role}-{N}`, so the whole accent layer recolors
+ * while semantic token names stay stable. Orthogonal to light/dark; persisted to
+ * localStorage (`rt-color-scheme`).
  */
 @Injectable({ providedIn: 'root' })
 export class RtThemeService {
@@ -22,12 +37,18 @@ export class RtThemeService {
     readonly #storage: Storage | null = inject(LOCAL_STORAGE, { optional: true }) ?? this.#document.defaultView?.localStorage ?? null;
 
     readonly #theme: WritableSignal<RtThemeType> = signal<RtThemeType>(this.#restore());
+    readonly #colorScheme: WritableSignal<string | null> = signal<string | null>(this.#restoreScheme());
 
     public readonly theme: Signal<RtThemeType> = this.#theme.asReadonly();
+    public readonly colorScheme: Signal<string | null> = this.#colorScheme.asReadonly();
 
     constructor() {
         effect((): void => {
             this.#apply(this.#theme());
+        });
+
+        effect((): void => {
+            this.#applyScheme(this.#colorScheme());
         });
     }
 
@@ -44,6 +65,46 @@ export class RtThemeService {
         this.setTheme(this.#isDarkApplied() ? RT_THEME_ENUM.LIGHT : RT_THEME_ENUM.DARK);
     }
 
+    /**
+     * Activates a registered color scheme by name, or clears it with `null`/`'default'`.
+     * Orthogonal to the light/dark theme; persisted to localStorage.
+     */
+    public setColorScheme(name: string | null): void {
+        const normalized: string | null = !name || name === RT_DEFAULT_SCHEME ? null : name;
+        this.#colorScheme.set(normalized);
+
+        if (this.#platformService.isPlatformBrowser && this.#storage) {
+            if (normalized) {
+                this.#storage.setItem(RT_COLOR_SCHEME_STORAGE_KEY, normalized);
+            } else {
+                this.#storage.removeItem(RT_COLOR_SCHEME_STORAGE_KEY);
+            }
+        }
+    }
+
+    /**
+     * Injects (or replaces) a color scheme's `[data-rt-scheme]` block at runtime —
+     * the JS twin of the `rt.color-scheme` Sass mixin. Browser-only (no-op on server;
+     * for SSR/brand-critical schemes prefer the Sass path). Does not activate the
+     * scheme — call {@link setColorScheme} afterwards.
+     */
+    public registerColorScheme(name: string, ramp: RtColorSchemeRamp): void {
+        if (!this.#platformService.isPlatformBrowser) {
+            return;
+        }
+
+        const id: string = `rt-color-scheme-${name}`;
+        const existing: HTMLElement | null = this.#document.getElementById(id);
+        const style: HTMLStyleElement = (existing as HTMLStyleElement | null) ?? this.#document.createElement('style');
+
+        style.id = id;
+        style.textContent = this.#buildSchemeCss(name, ramp);
+
+        if (!existing) {
+            this.#document.head.appendChild(style);
+        }
+    }
+
     #restore(): RtThemeType {
         if (!this.#platformService.isPlatformBrowser || !this.#storage) {
             return RT_THEME_ENUM.LIGHT;
@@ -52,6 +113,16 @@ export class RtThemeService {
         const stored: string | null = this.#storage.getItem(RT_THEME_STORAGE_KEY);
 
         return Object.values(RT_THEME_ENUM).includes(stored as RT_THEME_ENUM) ? (stored as RtThemeType) : RT_THEME_ENUM.LIGHT;
+    }
+
+    #restoreScheme(): string | null {
+        if (!this.#platformService.isPlatformBrowser || !this.#storage) {
+            return null;
+        }
+
+        const stored: string | null = this.#storage.getItem(RT_COLOR_SCHEME_STORAGE_KEY);
+
+        return stored && stored !== RT_DEFAULT_SCHEME ? stored : null;
     }
 
     #apply(theme: RtThemeType): void {
@@ -63,6 +134,31 @@ export class RtThemeService {
 
         classList.toggle(RT_DARK_CLASS, theme === RT_THEME_ENUM.DARK);
         classList.toggle(RT_THEME_AUTO_CLASS, theme === RT_THEME_ENUM.AUTO);
+    }
+
+    #applyScheme(name: string | null): void {
+        if (!this.#platformService.isPlatformBrowser) {
+            return;
+        }
+
+        const root: HTMLElement = this.#document.documentElement;
+
+        if (name) {
+            root.setAttribute(RT_SCHEME_ATTRIBUTE, name);
+        } else {
+            root.removeAttribute(RT_SCHEME_ATTRIBUTE);
+        }
+    }
+
+    /** Builds the `[data-rt-scheme="<name>"] { --rt-color-{role}-{N}: … }` block (mirrors the Sass mixin). */
+    #buildSchemeCss(name: string, ramp: RtColorSchemeRamp): string {
+        const declarations: string = Object.entries(ramp)
+            .flatMap(([role, tones]: [string, Record<number, string> | undefined]): string[] =>
+                Object.entries(tones ?? {}).map(([tone, value]: [string, string]): string => `--rt-color-${role}-${tone}:${value};`)
+            )
+            .join('');
+
+        return `[${RT_SCHEME_ATTRIBUTE}="${name}"]{${declarations}}`;
     }
 
     #isDarkApplied(): boolean {

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.types.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.types.ts
@@ -10,3 +10,37 @@ export const RT_THEME_STORAGE_KEY: string = 'rt-theme';
 export const RT_DARK_CLASS: string = 'rt-dark';
 export const RT_THEME_AUTO_CLASS: string = 'rt-theme-auto';
 export const RT_THEME_ATTRIBUTE: string = 'data-rt-theme';
+
+/**
+ * Accent roles whose `--rt-color-{role}-{0..100}` indirection rows a custom
+ * color scheme may override. The semantic accent tier
+ * (`--rt-bg/text/icon/border-accent-*`) derives entirely from these rows.
+ */
+export enum RT_ACCENT_ROLE_ENUM {
+    PRIMARY = 'primary',
+    INFO = 'info',
+    SUCCESS = 'success',
+    WARNING = 'warning',
+    DANGER = 'danger',
+    BRAND = 'brand',
+}
+
+export type RtAccentRole = `${RT_ACCENT_ROLE_ENUM}`;
+
+/**
+ * A brand palette: per accent role, a tonal ramp mapping tone step (0–100)
+ * to a CSS color. One ramp serves both light and dark (the mode picks the tone).
+ * Partial ramps are allowed — unset tones keep the rt-tools defaults.
+ *
+ * @example
+ * const teal: RtColorSchemeRamp = {
+ *     primary: { 20: '#b3e3e1', 40: '#5cb8b5', 60: '#1a9d99', 100: '#008582' },
+ *     brand:   { 20: '#e8e8e8', 100: '#008582' },
+ * };
+ */
+export type RtColorSchemeRamp = Partial<Record<RtAccentRole, Record<number, string>>>;
+
+/** `'default'`/`null` clears the active scheme (back to the rt-tools palette). */
+export const RT_DEFAULT_SCHEME: string = 'default';
+export const RT_COLOR_SCHEME_STORAGE_KEY: string = 'rt-color-scheme';
+export const RT_SCHEME_ATTRIBUTE: string = 'data-rt-scheme';

--- a/projects/ui-kit/src/lib/ui-kit/toggle/rtui-toggle.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/toggle/rtui-toggle.component.scss
@@ -13,7 +13,7 @@ $toggle: (
     toggle: (
         border-radius: 6.25rem,
         background-color: var(--rt-bg-base-subtle),
-        box-shadow: inset 0 0 0.125rem 0.0625rem rgba(0, 0, 0, 0.05),
+        box-shadow: inset 0 0 0.125rem 0.0625rem rgb(0 0 0 / 5%),
     ),
     toggle-check: (
         box-shadow: inset 0 0 0 1.25rem var(--rt-control-checked),
@@ -21,7 +21,7 @@ $toggle: (
     toggle-switch: (
         border-radius: 2.25rem,
         background-color: var(--rt-control-thumb),
-        box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.2),
+        box-shadow: 0 0.0625rem 0.125rem rgb(0 0 0 / 20%),
     ),
     toggle-track: (
         background-color: var(--rt-control-track),
@@ -79,12 +79,12 @@ $toggle: (
 
         .rtui-toggle {
             position: relative;
+            overflow: hidden;
             width: 3.125rem;
             min-width: 3.125rem;
             height: 1.875rem;
             border-radius: var(--rt-toggle-toggle-border-radius);
             background-color: var(--rt-toggle-toggle-background-color);
-            overflow: hidden;
             box-shadow: var(--rt-toggle-toggle-box-shadow);
             cursor: pointer;
 
@@ -103,36 +103,30 @@ $toggle: (
                     right: 0.125rem;
                     left: 1.375rem;
                     transition: 0.35s cubic-bezier(0.785, 0.135, 0.15, 0.86);
-                    transition-property: left, right;
                     transition-delay: 0.05s, 0s;
+                    transition-property: left, right;
                 }
             }
 
             &__switch {
                 position: absolute;
-                left: 0.125rem;
-                top: 0.125rem;
-                bottom: 0.125rem;
-                right: 1.375rem;
-                background-color: var(--rt-toggle-toggle-switch-background-color);
-                border-radius: var(--rt-toggle-toggle-switch-border-radius);
                 z-index: 1;
-                transition: 0.35s cubic-bezier(0.785, 0.135, 0.15, 0.86);
-                transition-property: left, right;
-                transition-delay: 0s, 0.05s;
+                border-radius: var(--rt-toggle-toggle-switch-border-radius);
+                background-color: var(--rt-toggle-toggle-switch-background-color);
                 box-shadow: var(--rt-toggle-toggle-switch-box-shadow);
+                inset: 0.125rem 1.375rem 0.125rem 0.125rem;
+                transition: 0.35s cubic-bezier(0.785, 0.135, 0.15, 0.86);
+                transition-delay: 0s, 0.05s;
+                transition-property: left, right;
             }
 
             &__track {
                 position: absolute;
-                left: 0;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                transition: 0.35s cubic-bezier(0.785, 0.135, 0.15, 0.86);
-                background-color: var(--rt-toggle-toggle-track-background-color);
-                border-radius: var(--rt-toggle-toggle-track-border-radius);
                 border: var(--rt-toggle-toggle-track-border);
+                border-radius: var(--rt-toggle-toggle-track-border-radius);
+                background-color: var(--rt-toggle-toggle-track-background-color);
+                inset: 0;
+                transition: 0.35s cubic-bezier(0.785, 0.135, 0.15, 0.86);
             }
 
             // modify
@@ -148,8 +142,8 @@ $toggle: (
                 }
 
                 .rtui-toggle__check:checked ~ .rtui-toggle__switch {
-                    left: 1.625rem;
                     right: 0.125rem;
+                    left: 1.625rem;
                 }
             }
 
@@ -165,8 +159,8 @@ $toggle: (
                 }
 
                 .rtui-toggle__check:checked ~ .rtui-toggle__switch {
-                    left: 0.75rem;
                     right: 0.125rem;
+                    left: 0.75rem;
                 }
             }
         }

--- a/projects/ui-kit/src/lib/ui-kit/toggle/rtui-toggle.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/toggle/rtui-toggle.component.ts
@@ -20,7 +20,7 @@ import { MatTooltip, TooltipPosition } from '@angular/material/tooltip';
 import { noop } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 import { BreakpointService } from '@rt-tools/utils';
 import { TOGGLE_SIZE_TYPE_ENUM, ToggleSizeType } from './toggle-size.type.enum';
 import { BooleanInput } from '@angular/cdk/coercion';
@@ -45,6 +45,7 @@ import { BooleanInput } from '@angular/cdk/coercion';
         // directives
         BlockDirective,
         ElemDirective,
+        ModDirective,
     ],
 })
 export class RtuiToggleComponent implements OnInit, ControlValueAccessor {

--- a/projects/ui-kit/src/lib/ui-kit/toggle/stories/component/test-toggle.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/toggle/stories/component/test-toggle.component.scss
@@ -1,9 +1,9 @@
 :host {
+    display: flex;
     width: 100vw;
     height: 100vh;
-    display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
     margin: -1rem;
 }

--- a/projects/ui-kit/src/lib/ui-kit/toolbar/toolbar.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/toolbar/toolbar.component.scss
@@ -40,9 +40,8 @@ $toolbar: (
         --mat-toolbar-standard-height: var(--rt-toolbar-body-mobile-height);
         --mdc-secondary-navigation-tab-container-height: var(--rt-toolbar-body-mobile-height);
 
-        min-height: var(--rt-toolbar-body-mobile-height);
         height: var(--rt-toolbar-body-mobile-height);
-
+        min-height: var(--rt-toolbar-body-mobile-height);
         padding: var(--rt-toolbar-body-padding);
         background-color: transparent;
 
@@ -61,16 +60,12 @@ $toolbar: (
 
         .bars {
             position: relative;
-
             display: flex;
             width: 100%;
             height: 100%;
-
+            border-bottom: var(--rt-toolbar-bars-border-bottom-width) var(--rt-toolbar-bars-border-bottom-style)
+                var(--rt-toolbar-bars-border-bottom-color);
             background-color: var(--rt-toolbar-body-background-color);
-
-            border-bottom-style: var(--rt-toolbar-bars-border-bottom-style);
-            border-bottom-width: var(--rt-toolbar-bars-border-bottom-width);
-            border-bottom-color: var(--rt-toolbar-bars-border-bottom-color);
 
             &__bar {
                 &--left {
@@ -78,8 +73,8 @@ $toolbar: (
                 }
 
                 &--center {
-                    width: var(--rt-toolbar-bars-center-width);
                     overflow: hidden;
+                    width: var(--rt-toolbar-bars-center-width);
                 }
 
                 &--right {
@@ -89,8 +84,8 @@ $toolbar: (
                 &--left,
                 &--center,
                 &--right {
-                    height: 100%;
                     display: flex;
+                    height: 100%;
                     align-items: center;
                 }
             }

--- a/projects/ui-kit/src/lib/ui-kit/toolbar/toolbar.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/toolbar/toolbar.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { MatToolbar } from '@angular/material/toolbar';
 
-import { BlockDirective, ElemDirective, Nullable } from '@rt-tools/core';
+import { BlockDirective, ElemDirective, ModDirective, Nullable } from '@rt-tools/core';
 
 @Directive({
     selector: '[rtuiToolbarLeft]',
@@ -35,7 +35,7 @@ export class RtuiToolbarRightDirective {}
     templateUrl: './toolbar.component.html',
     styleUrls: ['./toolbar.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [MatToolbar, NgTemplateOutlet, BlockDirective, ElemDirective],
+    imports: [MatToolbar, NgTemplateOutlet, BlockDirective, ElemDirective, ModDirective],
 })
 export class RtuiToolbarComponent {
     public isVisibleToolbar: Signal<boolean> = input(true);

--- a/projects/ui-kit/src/styles/TOKENS.md
+++ b/projects/ui-kit/src/styles/TOKENS.md
@@ -18,6 +18,9 @@ Quick facts:
   fallback chains. Opt out: `@use '...main' with ($tokens-use-material: false)`.
 - Accent roles `{primary,success,warning,danger,info,neutral}`,
   steps `{subtle,solid,hover,disabled}` (simplified vs GMT).
+- Accent indirection: the accent semantic tier derives from `--rt-color-{role}-{0..100}`
+  ramps (`{primary,info,success,warning,danger,brand}`). Custom brand palettes
+  override only those rows — see **Custom color schemes** below.
 - Foundations: `--rt-spacing-{0..64}` (px-named, rem values), `--rt-radius-*`,
   `--rt-font-*`, `--rt-shadow-*`, `--rt-transition-*`, `--rt-z-index-*`.
 - Prebuilt CSS for non-sass consumers: `dist/ui-kit/styles/tokens.css`
@@ -76,3 +79,43 @@ Both stay until the next major because consumers apply `.c-button` classes and o
 All **global** Material/CDK overrides live in `styles/components/_material-bridge.scss`
 (single file to review on a Material upgrade). Component-scoped piercings stay with their
 component; the bridge header keeps the inventory of those locations.
+
+## Custom color schemes (brand palettes)
+
+The accent semantic tier never hardcodes color — it derives from an indirection layer,
+the **accent-role ramps** `--rt-color-{role}-{0..100}` for
+`{primary, info, success, warning, danger, brand}`. A custom brand palette overrides
+**only** those rows; the kit derives `--rt-{bg,text,icon,border}-accent-*`,
+hover/subtle/disabled and `--rt-border-focus` from them. The block is scoped to
+`[data-rt-scheme="<name>"]` on `<html>`, set raw → it wins over `--mat-sys-*`.
+
+```scss
+@use '@rt-tools/ui-kit/src/styles/main' as rt;
+@include rt.color-scheme(
+    'teal',
+    (
+        primary: (
+            20: #b3e3e1,
+            40: #5cb8b5,
+            60: #1a9d99,
+            100: #008582,
+        ),
+        brand: (
+            20: #e8e8e8,
+            100: #008582,
+        ),
+    )
+);
+```
+
+```typescript
+// runtime twin (browser-only); prefer the Sass path for SSR/brand-critical schemes
+theme.registerColorScheme('teal', { primary: { 100: '#008582' /* … */ } });
+theme.setColorScheme('teal'); // data-rt-scheme="teal"; persisted to rt-color-scheme
+theme.setColorScheme(null); // back to the default palette
+```
+
+- Orthogonal to light/dark (one ramp per role serves both modes).
+- Δ0: with no scheme the accent layer is byte-for-byte the historical palette
+  (regression-tested in `styles/color-scheme.spec.ts`); Sass↔JS generator parity is tested too.
+- Full guide: Storybook **Foundation/Theming/Custom color schemes** (`docs/ColorSchemes.mdx`).

--- a/projects/ui-kit/src/styles/TOKENS.md
+++ b/projects/ui-kit/src/styles/TOKENS.md
@@ -20,12 +20,11 @@ Quick facts:
   steps `{subtle,solid,hover,disabled}` (simplified vs GMT).
 - Foundations: `--rt-spacing-{0..64}` (px-named, rem values), `--rt-radius-*`,
   `--rt-font-*`, `--rt-shadow-*`, `--rt-transition-*`, `--rt-z-index-*`.
-- Legacy `--clr-*` variables are emitted as **deprecated aliases**.
 - Prebuilt CSS for non-sass consumers: `dist/ui-kit/styles/tokens.css`
   (`pnpm run build:tokens`).
 - Figma parity: collections `core` (`rt/color/*`) and `theme` (`rt/{bg,text,icon,border}/*`,
   Light/Dark modes) in the “RT-Tools UI Kit” file mirror these names 1:1.
-- App-defined (never set by the kit): `--clr-avalon`, `--font-default`, mat theme colors.
+- App-defined (never set by the kit): `--font-default`, mat theme colors.
 
 ## Component theming API (Tier 3 contract)
 
@@ -52,7 +51,7 @@ major the internal set stops being emitted and gets inlined into rules.
   aside-panel) are overridable from any ancestor scope: `.dark-mode { --rt-aside-host-background-color: …; }`.
 - Vars emitted at **`:host`** are set on the element itself and **win over inherited values** —
   consumers must target the element (`rtui-toolbar { --rt-toolbar-body-height: … !important; }`).
-  This asymmetry is why Avalon needs `!important` for toolbar/toggle but not for aside/table.
+  This asymmetry is why some consumers need `!important` for toolbar/toggle but not for aside/table.
 - Planned unification (major): emit defaults via `var(--override, default)` indirection so all
   components are ancestor-overridable without `!important`.
 

--- a/projects/ui-kit/src/styles/TOKENS.md
+++ b/projects/ui-kit/src/styles/TOKENS.md
@@ -26,3 +26,54 @@ Quick facts:
 - Figma parity: collections `core` (`rt/color/*`) and `theme` (`rt/{bg,text,icon,border}/*`,
   Light/Dark modes) in the “RT-Tools UI Kit” file mirror these names 1:1.
 - App-defined (never set by the kit): `--clr-avalon`, `--font-default`, mat theme colors.
+
+## Component theming API (Tier 3 contract)
+
+Tier-3 vars are split into a **public theming API** and **internal implementation details**.
+Only the public set is a compatibility promise; internal vars may be renamed or stop being
+emitted in the next major release.
+
+**Public** (override these from your app):
+
+1. Every var matching `--rt-<component>-*-{color,background-color,bg,shadow,indicator}` —
+   the color surface of each component.
+2. Documented size hooks proven by consumers:
+   `--rt-table-row-height`, `--rt-toolbar-body-height`, `--rt-toolbar-body-mobile-height`,
+   `--rt-aside-error-box-height`, `--rt-aside-host-width`,
+   `--rt-image-upload-host-min-height`, `--rt-image-upload-image-container-image-max-height`.
+
+**Internal** (everything else): layout paddings/margins/gaps/font-sizes generated from SCSS maps.
+They currently _are_ emitted (≈380 vars total, ~14% actually themed by consumers) — in the next
+major the internal set stops being emitted and gets inlined into rules.
+
+### `:root` vs `:host` emission — override semantics
+
+- Vars emitted at **`:root`** (global stylesheets + `ViewEncapsulation.None` components like
+  aside-panel) are overridable from any ancestor scope: `.dark-mode { --rt-aside-host-background-color: …; }`.
+- Vars emitted at **`:host`** are set on the element itself and **win over inherited values** —
+  consumers must target the element (`rtui-toolbar { --rt-toolbar-body-height: … !important; }`).
+  This asymmetry is why Avalon needs `!important` for toolbar/toggle but not for aside/table.
+- Planned unification (major): emit defaults via `var(--override, default)` indirection so all
+  components are ancestor-overridable without `!important`.
+
+## Buttons: legacy vs rtui
+
+`.c-button` (\_button.scss) is **deprecated**; `.rtui-btn` (\_rtui_button.scss) is the system.
+Both stay until the next major because consumers apply `.c-button` classes and override
+`--rt-button-*` directly. Migration map:
+
+| legacy `.c-button`        | `.rtui-btn`                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `--fill-green` / `-light` | `rtui-btn-success` / `-light`                                         |
+| `--fill-red` / `-light`   | `rtui-btn-error` / `-light`                                           |
+| `--fill-blue`             | `rtui-btn-accent-light`                                               |
+| `--fill-base/black/gray`  | `rtui-btn-secondary` (+`-light`)                                      |
+| `--outline-{blue,base}`   | `rtui-btn-{accent,secondary}-outline`                                 |
+| `--txt-*`, `--fab`        | no equivalent yet — needs a text/icon appearance in `.rtui-btn` first |
+| `--size-{sm,md,l}`        | `rtui-btn-{sm,md,lg}` (+`-full`)                                      |
+
+## Material bridge
+
+All **global** Material/CDK overrides live in `styles/components/_material-bridge.scss`
+(single file to review on a Material upgrade). Component-scoped piercings stay with their
+component; the bridge header keeps the inventory of those locations.

--- a/projects/ui-kit/src/styles/base/_base.scss
+++ b/projects/ui-kit/src/styles/base/_base.scss
@@ -1,6 +1,6 @@
 $palette: (
     white: (
-        100: #ffffff,
+        100: #fff,
     ),
     gray: (
         5: #f5f6f8,
@@ -10,7 +10,7 @@ $palette: (
     ),
     black: (
         10: #f3f3f3,
-        15: #eeeeee,
+        15: #eee,
         20: #e0e0e0,
         30: #b2cbca,
         40: #a3a3a3,
@@ -60,5 +60,5 @@ $palette: (
 
 :root {
     // Buttons
-    --rt-button-box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.12), 0 1px 18px 0 rgba(0, 0, 0, 0.14);
+    --rt-button-box-shadow: 0 3px 5px -1px rgb(0 0 0 / 20%), 0 6px 10px 0 rgb(0 0 0 / 12%), 0 1px 18px 0 rgb(0 0 0 / 14%);
 }

--- a/projects/ui-kit/src/styles/base/_base.scss
+++ b/projects/ui-kit/src/styles/base/_base.scss
@@ -55,8 +55,7 @@ $palette: (
 
 // NOTE: the $palette map above is kept for backwards compatibility (consumers may @use it).
 // All CSS custom property emission lives in base/_tokens.scss:
-//   --rt-color-* primitives, --rt-{bg,text,icon,border}-* semantic, foundations,
-//   and deprecated --clr-* aliases.
+//   --rt-color-* primitives, --rt-{bg,text,icon,border}-* semantic, and foundations.
 
 :root {
     // Buttons

--- a/projects/ui-kit/src/styles/base/_color-scheme.scss
+++ b/projects/ui-kit/src/styles/base/_color-scheme.scss
@@ -44,7 +44,7 @@ $known-roles: tokens.$accent-roles;
     }
 
     @each $step, $value in $ramp {
-        @if meta.type-of($step) != 'number' or not math-is-integer-step($step) {
+        @if meta.type-of($step) != 'number' or not _is-integer-step($step) {
             @error 'rt.color-scheme("#{$name}"): role "#{$role}" tone "#{$step}" must be an integer 0–100.';
         }
     }
@@ -53,7 +53,7 @@ $known-roles: tokens.$accent-roles;
 }
 
 /// Tone steps must be integers within 0–100.
-@function math-is-integer-step($step) {
+@function _is-integer-step($step) {
     @return $step >= 0 and $step <= 100 and ($step % 1 == 0);
 }
 
@@ -75,7 +75,8 @@ $known-roles: tokens.$accent-roles;
         $ok: _validate-role($name, $role, $ramp);
     }
 
-    [data-rt-scheme='#{$name}'] {
+    // `:root[...]` (0,2,0) outranks the default `:root` rows (0,1,0) regardless of source order.
+    :root[data-rt-scheme='#{$name}'] {
         @each $role, $ramp in $roles {
             @each $step, $value in $ramp {
                 --rt-color-#{$role}-#{$step}: #{$value};

--- a/projects/ui-kit/src/styles/base/_color-scheme.scss
+++ b/projects/ui-kit/src/styles/base/_color-scheme.scss
@@ -1,0 +1,85 @@
+@use 'sass:map';
+@use 'sass:meta';
+@use 'sass:list';
+@use './tokens' as tokens;
+
+/// ============================================================================
+/// Custom color schemes (brand palettes)
+/// ============================================================================
+///
+/// A color scheme overrides ONLY the accent-role indirection rows
+/// `--rt-color-{role}-{0..100}` (see `_tokens.scss`). The whole semantic accent
+/// tier (`--rt-bg/text/icon/border-accent-*`, hover/subtle/disabled, `--rt-border-focus`)
+/// re-derives from those rows — so a brand recolors with Δ0 effort and the
+/// component contract (semantic token names) stays untouched.
+///
+/// The emitted block is scoped to `[data-rt-scheme="<name>"]`, which the runtime
+/// (`RtThemeService.setColorScheme`) toggles on `<html>`. Because the scheme sets
+/// raw values, it overrides the default rows that carry the `--mat-sys-*` fallback
+/// → the scheme wins over an active Material theme.
+///
+/// Usage:
+///   @use '@rt-tools/ui-kit/src/styles/main' as rt;   // or the package's scss entry
+///   @include rt.color-scheme('teal', (
+///       primary: (20: #b3e3e1, 40: #5cb8b5, 60: #1a9d99, 100: #008582),
+///       brand:   (20: #e8e8e8, 100: #008582),
+///   ));
+///
+/// One tonal ramp per role serves both light and dark (M3-style): the mode picks
+/// the tone via `light-dark()` inside the semantic tier — schemes never duplicate
+/// that logic. `$modes` is accepted for forward-compatibility but a single ramp
+/// already covers every mode.
+
+/// Roles a scheme may override, with their valid tone steps (from the default ramps).
+$known-roles: tokens.$accent-roles;
+
+/// Validate a single role/ramp pair; @error with an actionable message on bad input.
+@function _validate-role($name, $role, $ramp) {
+    @if not map.has-key($known-roles, $role) {
+        @error 'rt.color-scheme("#{$name}"): unknown role "#{$role}". Allowed roles: #{map.keys($known-roles)}.';
+    }
+
+    @if meta.type-of($ramp) != 'map' {
+        @error 'rt.color-scheme("#{$name}"): role "#{$role}" must be a map of (tone: color), got #{meta.type-of($ramp)}.';
+    }
+
+    @each $step, $value in $ramp {
+        @if meta.type-of($step) != 'number' or not math-is-integer-step($step) {
+            @error 'rt.color-scheme("#{$name}"): role "#{$role}" tone "#{$step}" must be an integer 0–100.';
+        }
+    }
+
+    @return true;
+}
+
+/// Tone steps must be integers within 0–100.
+@function math-is-integer-step($step) {
+    @return $step >= 0 and $step <= 100 and ($step % 1 == 0);
+}
+
+/// Emit a named color scheme as a `[data-rt-scheme]` block (only raw `--rt-color-{role}-{N}` rows).
+///
+/// @param {String} $name   Scheme name, matched by `data-rt-scheme="<name>"`.
+/// @param {Map}    $roles  Map of `role: (tone: color, …)`. Roles ⊆ #{map.keys($known-roles)}.
+/// @param {List}   $modes  Reserved for forward-compat; one ramp already serves all modes.
+@mixin color-scheme($name, $roles, $modes: (light, dark)) {
+    @if meta.type-of($name) != 'string' {
+        @error 'rt.color-scheme: $name must be a string, got #{meta.type-of($name)}.';
+    }
+
+    @if meta.type-of($roles) != 'map' or list.length(map.keys($roles)) == 0 {
+        @error 'rt.color-scheme("#{$name}"): $roles must be a non-empty map of (role: ramp).';
+    }
+
+    @each $role, $ramp in $roles {
+        $ok: _validate-role($name, $role, $ramp);
+    }
+
+    [data-rt-scheme='#{$name}'] {
+        @each $role, $ramp in $roles {
+            @each $step, $value in $ramp {
+                --rt-color-#{$role}-#{$step}: #{$value};
+            }
+        }
+    }
+}

--- a/projects/ui-kit/src/styles/base/_mixin.scss
+++ b/projects/ui-kit/src/styles/base/_mixin.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use 'sass:math';
 @use './variables' as vars;
 
@@ -16,9 +17,9 @@
 // convert hex to rgb values
 // #{convert-hex-to-rgb-values(#ab2727)}: 171, 39, 39;
 @function convert-hex-to-rgb-values($hex) {
-    $r: red($hex);
-    $g: green($hex);
-    $b: blue($hex);
+    $r: color.channel($hex, 'red', $space: rgb);
+    $g: color.channel($hex, 'green', $space: rgb);
+    $b: color.channel($hex, 'blue', $space: rgb);
 
     @return $r + ', ' + $g + ', ' + $b;
 }
@@ -26,6 +27,7 @@
 // px to rem
 // font-size: rem(16);
 $browser-context: 16;
+
 @function rem($valueRem, $context: $browser-context) {
     @return #{math.div($valueRem, $context)}rem;
 }
@@ -47,20 +49,21 @@ $browser-context: 16;
 @mixin flex-column-center {
     display: flex;
     flex-direction: column;
-    justify-content: center;
     align-items: center;
+    justify-content: center;
 }
 
 @mixin visually-hidden {
     position: absolute;
+    overflow: hidden;
     width: 1px;
     height: 1px;
-    margin: -1px;
-    border: 0;
     padding: 0;
-    white-space: nowrap;
-    clip-path: inset(100%);
+    border: 0;
+    margin: -1px;
+    /* stylelint-disable-next-line property-no-deprecated -- legacy-browser leg of the visually-hidden pattern */
     clip: rect(0 0 0 0);
-    overflow: hidden;
+    clip-path: inset(100%);
     pointer-events: none;
+    white-space: nowrap;
 }

--- a/projects/ui-kit/src/styles/base/_mixin.scss
+++ b/projects/ui-kit/src/styles/base/_mixin.scss
@@ -2,12 +2,6 @@
 @use 'sass:math';
 @use './variables' as vars;
 
-// css clr var generator
-// #{generateCssVar(red, 100)}: #eb5055;
-@function generateCssClrVar($color, $saturate) {
-    @return --#{vars.$styles-clr-prefix}-#{$color}-#{$saturate};
-}
-
 // css var generator
 // #{generateCssVar(table-base-cell, suffix-icon, size)}: 1rem;
 @function generateCssVar($component-name, $element, $style-token) {

--- a/projects/ui-kit/src/styles/base/_tokens.scss
+++ b/projects/ui-kit/src/styles/base/_tokens.scss
@@ -345,31 +345,6 @@ $breakpoint: (
     @each $token, $value in $breakpoint {
         --rt-breakpoint-#{$token}: #{$value};
     }
-
-    /* --- Deprecated aliases (legacy --clr-*; remove after consumers migrate) --- */
-    --clr-white-100: var(--rt-color-neutral-0);
-    --clr-gray-5: var(--rt-color-neutral-5);
-    --clr-gray-10: var(--rt-color-neutral-20);
-    --clr-gray-15: var(--rt-color-neutral-30);
-    --clr-gray-20: var(--rt-color-neutral-35);
-    --clr-black-10: var(--rt-color-neutral-10);
-    --clr-black-15: var(--rt-color-neutral-15);
-    --clr-black-20: var(--rt-color-neutral-25);
-    --clr-black-30: #b2cbca; // palette outlier, kept verbatim
-    --clr-black-40: var(--rt-color-neutral-40);
-    --clr-black-60: var(--rt-color-neutral-60);
-    --clr-black-80: var(--rt-color-neutral-80);
-    --clr-black-100: var(--rt-color-neutral-100);
-
-    @each $hue, $steps in $hues {
-        @each $step, $value in $steps {
-            --clr-#{$hue}-#{$step}: var(--rt-color-#{$hue}-#{$step});
-        }
-    }
-
-    --clr-txt: var(--rt-text-base-primary);
-    --clr-base-accent: var(--rt-color-brand);
-    --clr-white-rgb: 255, 255, 255;
 }
 
 /* Theme switching: global class + nested local contexts (GMT data-theme analogue) */

--- a/projects/ui-kit/src/styles/base/_tokens.scss
+++ b/projects/ui-kit/src/styles/base/_tokens.scss
@@ -117,6 +117,8 @@ $overlay-steps: (5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90);
 // Material system color carry the `--mat-sys-*` fallback INSIDE the tone (`t(..., null, $mat)`), so:
 //   - default render honors Material (as before);
 //   - a scheme override replaces the tone with a raw value → the scheme wins over Material.
+// `brand` is navy in light (100) / near-white in dark (20); both carry mat-sys-primary because the
+// original text/icon-accent-brand mapped to --mat-sys-primary.
 $accent-roles: (
     'primary': (
         20: t(#eaedfc, null, primary-container),

--- a/projects/ui-kit/src/styles/base/_tokens.scss
+++ b/projects/ui-kit/src/styles/base/_tokens.scss
@@ -31,11 +31,11 @@ $use-material: true !default;
 @function t($light, $dark: null, $mat: null) {
     $v: $light;
 
-    @if $dark != null {
+    @if $dark {
         $v: light-dark(#{$light}, #{$dark});
     }
 
-    @if $mat != null and $use-material {
+    @if $mat and $use-material {
         @return var(--mat-sys-#{$mat}, #{$v});
     }
 
@@ -46,14 +46,14 @@ $use-material: true !default;
 
 // Unified neutral scale (sorted by lightness, sourced from the legacy white/gray/black families)
 $neutral: (
-    0: #ffffff,
+    0: #fff,
     5: #f5f6f8,
     10: #f3f3f3,
-    15: #eeeeee,
+    15: #eee,
     20: #e8e8e8,
     25: #e0e0e0,
     30: #d1d1d1,
-    35: #cccccc,
+    35: #ccc,
     40: #a3a3a3,
     60: #747474,
     80: #323033,
@@ -105,7 +105,6 @@ $hue-base: (
     'green': #01af8d,
     'brand': #0d1c2b,
 );
-
 $opacity-steps: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90);
 $overlay-steps: (5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90);
 
@@ -114,52 +113,52 @@ $overlay-steps: (5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90);
 // honoring a `with ($use-material: ...)` configuration.
 
 $semantic: (
-    /* ---- bg / base (adaptive) ---- */ bg-base-base: t(#ffffff, #1c1b1e, surface),
-    bg-base-elevated: t(#ffffff, #2a292d, surface-container),
+    /* ---- bg / base (adaptive) ---- */ bg-base-base: t(#fff, #1c1b1e, surface),
+    bg-base-elevated: t(#fff, #2a292d, surface-container),
     bg-base-subtle: t(#f5f6f8, #232226),
-    bg-base-hover: t(#f3f3f3, rgba(255, 255, 255, 0.06)),
-    bg-base-active: t(#eeeeee, rgba(255, 255, 255, 0.1)),
+    bg-base-hover: t(#f3f3f3, rgb(255 255 255 / 6%)),
+    bg-base-active: t(#eee, rgb(255 255 255 / 10%)),
     bg-base-strong: t(#e0e0e0, #3f3e43),
     bg-base-emphasis: t(#747474, #a3a3a3),
     bg-base-emphasis-soft: t(#a3a3a3, #747474),
     bg-base-inverse: t(#181818, #f3f3f3, inverse-surface),
-    bg-base-inverse-soft: t(#323033, #eeeeee),
-    bg-base-overlay: t(rgba(0, 0, 0, 0.32), rgba(0, 0, 0, 0.6)),
-    /* ---- bg / static ---- */ bg-static-light: #ffffff,
+    bg-base-inverse-soft: t(#323033, #eee),
+    bg-base-overlay: t(rgb(0 0 0 / 32%), rgb(0 0 0 / 60%)),
+    /* ---- bg / static ---- */ bg-static-light: #fff,
     bg-static-dark: #181818,
     bg-static-none: transparent,
     /* ---- bg / accent: {subtle, solid, hover, disabled} (simplified GMT scale) ---- */
     bg-accent-primary-subtle: t(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e), primary-container),
     bg-accent-primary-solid: t(#4284d7, #4284d7, primary),
-    bg-accent-primary-hover: t(color-mix(in srgb, #4284d7 90%, #000000), color-mix(in srgb, #4284d7 90%, #ffffff)),
+    bg-accent-primary-hover: t(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff)),
     bg-accent-primary-disabled: color-mix(in srgb, #4284d7 38%, transparent),
     bg-accent-success-subtle: t(#e5f8f4, color-mix(in srgb, #01af8d 18%, #1c1b1e)),
     bg-accent-success-solid: #21b18e,
-    bg-accent-success-hover: t(color-mix(in srgb, #21b18e 90%, #000000), color-mix(in srgb, #21b18e 90%, #ffffff)),
+    bg-accent-success-hover: t(color-mix(in srgb, #21b18e 90%, #000), color-mix(in srgb, #21b18e 90%, #fff)),
     bg-accent-success-disabled: color-mix(in srgb, #21b18e 38%, transparent),
     bg-accent-warning-subtle: t(#e8cbbf, color-mix(in srgb, #ef7128 18%, #1c1b1e)),
     bg-accent-warning-solid: #ee7a34,
-    bg-accent-warning-hover: t(color-mix(in srgb, #ee7a34 90%, #000000), color-mix(in srgb, #ee7a34 90%, #ffffff)),
+    bg-accent-warning-hover: t(color-mix(in srgb, #ee7a34 90%, #000), color-mix(in srgb, #ee7a34 90%, #fff)),
     bg-accent-warning-disabled: color-mix(in srgb, #ee7a34 38%, transparent),
     bg-accent-danger-subtle: t(#fdedee, color-mix(in srgb, #eb5055 18%, #1c1b1e), error-container),
     bg-accent-danger-solid: t(#eb5055, #eb5055, error),
-    bg-accent-danger-hover: t(color-mix(in srgb, #eb5055 90%, #000000), color-mix(in srgb, #eb5055 90%, #ffffff)),
+    bg-accent-danger-hover: t(color-mix(in srgb, #eb5055 90%, #000), color-mix(in srgb, #eb5055 90%, #fff)),
     bg-accent-danger-disabled: color-mix(in srgb, #eb5055 38%, transparent),
     bg-accent-info-subtle: t(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e)),
     bg-accent-info-solid: #4284d7,
-    bg-accent-info-hover: t(color-mix(in srgb, #4284d7 90%, #000000), color-mix(in srgb, #4284d7 90%, #ffffff)),
+    bg-accent-info-hover: t(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff)),
     bg-accent-info-disabled: color-mix(in srgb, #4284d7 38%, transparent),
-    bg-accent-neutral-subtle: t(#f3f3f3, rgba(255, 255, 255, 0.06)),
+    bg-accent-neutral-subtle: t(#f3f3f3, rgb(255 255 255 / 6%)),
     bg-accent-neutral-solid: t(#747474, #a3a3a3),
     bg-accent-neutral-hover: t(#a3a3a3, #747474),
-    bg-accent-neutral-disabled: t(rgba(116, 116, 116, 0.38), rgba(163, 163, 163, 0.38)),
-    /* ---- text / base (adaptive) ---- */ text-base-primary: t(rgba(0, 0, 0, 0.87), rgba(255, 255, 255, 0.87), on-surface),
+    bg-accent-neutral-disabled: t(rgb(116 116 116 / 38%), rgb(163 163 163 / 38%)),
+    /* ---- text / base (adaptive) ---- */ text-base-primary: t(rgb(0 0 0 / 87%), rgb(255 255 255 / 87%), on-surface),
     text-base-strong: t(#181818, #f3f3f3),
     text-base-soft: t(#323033, #e0e0e0),
     text-base-secondary: t(#747474, #a3a3a3, on-surface-variant),
     text-base-disabled: t(#a3a3a3, #747474),
-    text-base-inverse: t(#ffffff, #181818, inverse-on-surface),
-    /* ---- text / static ---- */ text-static-light: #ffffff,
+    text-base-inverse: t(#fff, #181818, inverse-on-surface),
+    /* ---- text / static ---- */ text-static-light: #fff,
     text-static-dark: #181818,
     /* ---- text / accent ---- */ text-accent-brand: t(#0d1c2b, #e8e8e8, primary),
     text-accent-primary: t(#4284d7, #6d96e8, primary),
@@ -174,8 +173,8 @@ $semantic: (
     /* ---- icon / neutral (adaptive) ---- */ icon-neutral-default: t(#323033, #e0e0e0),
     icon-neutral-soft: t(#747474, #a3a3a3),
     icon-neutral-disabled: t(#a3a3a3, #747474),
-    icon-neutral-inverse: t(#ffffff, #181818),
-    /* ---- icon / static ---- */ icon-static-light: #ffffff,
+    icon-neutral-inverse: t(#fff, #181818),
+    /* ---- icon / static ---- */ icon-static-light: #fff,
     icon-static-dark: #181818,
     /* ---- icon / accent ---- */ icon-accent-brand: t(#0d1c2b, #e8e8e8, primary),
     icon-accent-primary: t(#4284d7, #6d96e8, primary),
@@ -186,7 +185,7 @@ $semantic: (
     /* ---- border / neutral (adaptive) ---- */ border-neutral-subtle: t(#e8e8e8, #2e2d31),
     border-neutral-default: t(#e0e0e0, #3f3e43, outline-variant),
     border-neutral-medium: t(#d1d1d1, #4a494e),
-    border-neutral-divider: t(#cccccc, #4a494e),
+    border-neutral-divider: t(#ccc, #4a494e),
     border-neutral-strong: t(#a3a3a3, #5c5b60, outline),
     border-neutral-emphasis: t(#747474, #a3a3a3),
     /* ---- border / accent ---- */ border-accent-primary: t(#4284d7, #6d96e8, primary),
@@ -197,11 +196,11 @@ $semantic: (
     border-accent-info: #4284d7,
     border-focus: t(#b3ceef, #6d96e8),
     /* ---- form controls (rt extension) ---- */ control-track: t(#e8e8e8, #4a494e),
-    control-thumb: t(#ffffff, #eeeeee),
+    control-thumb: t(#fff, #eee),
     control-checked: t(#323033, #e0e0e0),
-    /* ---- misc ---- */ scrollbar-thumb: t(#cccccc, #4a494e),
+    /* ---- misc ---- */ scrollbar-thumb: t(#ccc, #4a494e),
     scrollbar-thumb-hover: t(#a3a3a3, #5c5b60),
-    shadow-color: t(#747474, rgba(0, 0, 0, 0.6))
+    shadow-color: t(#747474, rgb(0 0 0 / 60%))
 );
 
 /* ============================== Foundations (mode-independent) ============================== */
@@ -222,7 +221,6 @@ $spacing: (
     56: 3.5rem,
     64: 4rem,
 );
-
 $radius: (
     xs: 0.25rem,
     sm: 0.5rem,
@@ -232,7 +230,6 @@ $radius: (
     2xl: 2rem,
     full: 624.9375rem,
 );
-
 $font-size: (
     xs: 0.75rem,
     sm: 0.875rem,
@@ -240,32 +237,28 @@ $font-size: (
     lg: 1.25rem,
     xl: 1.5rem,
 );
-
 $font-weight: (
     regular: 400,
     medium: 500,
     semibold: 600,
     bold: 700,
 );
-
 $shadow: (
     sm: (
-        0 0.0625rem 0.25rem 0 rgba(0, 0, 0, 0.12),
+        0 0.0625rem 0.25rem 0 rgb(0 0 0 / 12%),
     ),
     md: (
-        0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.14),
+        0 0.25rem 0.5rem 0 rgb(0 0 0 / 14%),
     ),
     lg: (
         0 0.5rem 1rem 0 var(--rt-shadow-color),
     ),
 );
-
 $transition: (
     fast: 0.15s ease-in-out,
     base: 0.25s ease-in-out,
     slow: 0.4s ease-in-out,
 );
-
 $z-index: (
     dropdown: 1000,
     sticky: 1020,
@@ -324,24 +317,31 @@ $breakpoint: (
     @each $token, $value in $spacing {
         --rt-spacing-#{$token}: #{$value};
     }
+
     @each $token, $value in $radius {
         --rt-radius-#{$token}: #{$value};
     }
+
     @each $token, $value in $font-size {
         --rt-font-size-#{$token}: #{$value};
     }
+
     @each $token, $value in $font-weight {
         --rt-font-weight-#{$token}: #{$value};
     }
+
     @each $token, $value in $shadow {
         --rt-shadow-#{$token}: #{$value};
     }
+
     @each $token, $value in $transition {
         --rt-transition-#{$token}: #{$value};
     }
+
     @each $token, $value in $z-index {
         --rt-z-index-#{$token}: #{$value};
     }
+
     @each $token, $value in $breakpoint {
         --rt-breakpoint-#{$token}: #{$value};
     }
@@ -360,11 +360,13 @@ $breakpoint: (
     --clr-black-60: var(--rt-color-neutral-60);
     --clr-black-80: var(--rt-color-neutral-80);
     --clr-black-100: var(--rt-color-neutral-100);
+
     @each $hue, $steps in $hues {
         @each $step, $value in $steps {
             --clr-#{$hue}-#{$step}: var(--rt-color-#{$hue}-#{$step});
         }
     }
+
     --clr-txt: var(--rt-text-base-primary);
     --clr-base-accent: var(--rt-color-brand);
     --clr-white-rgb: 255, 255, 255;

--- a/projects/ui-kit/src/styles/base/_tokens.scss
+++ b/projects/ui-kit/src/styles/base/_tokens.scss
@@ -108,6 +108,48 @@ $hue-base: (
 $opacity-steps: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90);
 $overlay-steps: (5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90);
 
+/* ------------------------------ Accent-role ramps (indirection layer) ------------------------------ */
+// The semantic accent tier references ONLY these `--rt-color-{role}-{0..100}` rows — never raw hues.
+// A custom color scheme overrides just these rows (see `_color-scheme.scss`) and the entire
+// accent layer (bg/text/icon/border + hover/subtle/disabled/focus derivations) recolors with Δ0 effort.
+// ---
+// Defaults reproduce the historical own-palette byte-for-byte. Tones that previously mapped to a
+// Material system color carry the `--mat-sys-*` fallback INSIDE the tone (`t(..., null, $mat)`), so:
+//   - default render honors Material (as before);
+//   - a scheme override replaces the tone with a raw value → the scheme wins over Material.
+$accent-roles: (
+    'primary': (
+        20: t(#eaedfc, null, primary-container),
+        40: #b3ceef,
+        60: t(#6d96e8, null, primary),
+        100: t(#4284d7, null, primary),
+    ),
+    'info': (
+        20: #eaedfc,
+        80: #4285f4,
+        100: #4284d7,
+    ),
+    'success': (
+        10: #e5f8f4,
+        80: #21b18e,
+        100: #01af8d,
+    ),
+    'warning': (
+        10: #e8cbbf,
+        80: #ee7a34,
+        100: #ef7128,
+    ),
+    'danger': (
+        10: t(#fdedee, null, error-container),
+        60: #e88487,
+        100: t(#eb5055, null, error),
+    ),
+    'brand': (
+        20: t(#e8e8e8, null, primary),
+        100: t(#0d1c2b, null, primary),
+    ),
+);
+
 /* ============================== Tier 2: semantic ============================== */
 // NOTE: function calls in this map are evaluated when the module loads,
 // honoring a `with ($use-material: ...)` configuration.
@@ -127,27 +169,39 @@ $semantic: (
     /* ---- bg / static ---- */ bg-static-light: #fff,
     bg-static-dark: #181818,
     bg-static-none: transparent,
-    /* ---- bg / accent: {subtle, solid, hover, disabled} (simplified GMT scale) ---- */
-    bg-accent-primary-subtle: t(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e), primary-container),
-    bg-accent-primary-solid: t(#4284d7, #4284d7, primary),
-    bg-accent-primary-hover: t(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff)),
-    bg-accent-primary-disabled: color-mix(in srgb, #4284d7 38%, transparent),
-    bg-accent-success-subtle: t(#e5f8f4, color-mix(in srgb, #01af8d 18%, #1c1b1e)),
-    bg-accent-success-solid: #21b18e,
-    bg-accent-success-hover: t(color-mix(in srgb, #21b18e 90%, #000), color-mix(in srgb, #21b18e 90%, #fff)),
-    bg-accent-success-disabled: color-mix(in srgb, #21b18e 38%, transparent),
-    bg-accent-warning-subtle: t(#e8cbbf, color-mix(in srgb, #ef7128 18%, #1c1b1e)),
-    bg-accent-warning-solid: #ee7a34,
-    bg-accent-warning-hover: t(color-mix(in srgb, #ee7a34 90%, #000), color-mix(in srgb, #ee7a34 90%, #fff)),
-    bg-accent-warning-disabled: color-mix(in srgb, #ee7a34 38%, transparent),
-    bg-accent-danger-subtle: t(#fdedee, color-mix(in srgb, #eb5055 18%, #1c1b1e), error-container),
-    bg-accent-danger-solid: t(#eb5055, #eb5055, error),
-    bg-accent-danger-hover: t(color-mix(in srgb, #eb5055 90%, #000), color-mix(in srgb, #eb5055 90%, #fff)),
-    bg-accent-danger-disabled: color-mix(in srgb, #eb5055 38%, transparent),
-    bg-accent-info-subtle: t(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e)),
-    bg-accent-info-solid: #4284d7,
-    bg-accent-info-hover: t(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff)),
-    bg-accent-info-disabled: color-mix(in srgb, #4284d7 38%, transparent),
+    /* ---- bg / accent: {subtle, solid, hover, disabled} — driven by --rt-color-{role}-{N} ---- */
+    bg-accent-primary-subtle: t(var(--rt-color-primary-20), color-mix(in srgb, var(--rt-color-primary-100) 18%, #1c1b1e)),
+    bg-accent-primary-solid: var(--rt-color-primary-100),
+    bg-accent-primary-hover: t(
+            color-mix(in srgb, var(--rt-color-primary-100) 90%, #000),
+            color-mix(in srgb, var(--rt-color-primary-100) 90%, #fff)
+        ),
+    bg-accent-primary-disabled: color-mix(in srgb, var(--rt-color-primary-100) 38%, transparent),
+    bg-accent-success-subtle: t(var(--rt-color-success-10), color-mix(in srgb, var(--rt-color-success-100) 18%, #1c1b1e)),
+    bg-accent-success-solid: var(--rt-color-success-80),
+    bg-accent-success-hover: t(
+            color-mix(in srgb, var(--rt-color-success-80) 90%, #000),
+            color-mix(in srgb, var(--rt-color-success-80) 90%, #fff)
+        ),
+    bg-accent-success-disabled: color-mix(in srgb, var(--rt-color-success-80) 38%, transparent),
+    bg-accent-warning-subtle: t(var(--rt-color-warning-10), color-mix(in srgb, var(--rt-color-warning-100) 18%, #1c1b1e)),
+    bg-accent-warning-solid: var(--rt-color-warning-80),
+    bg-accent-warning-hover: t(
+            color-mix(in srgb, var(--rt-color-warning-80) 90%, #000),
+            color-mix(in srgb, var(--rt-color-warning-80) 90%, #fff)
+        ),
+    bg-accent-warning-disabled: color-mix(in srgb, var(--rt-color-warning-80) 38%, transparent),
+    bg-accent-danger-subtle: t(var(--rt-color-danger-10), color-mix(in srgb, var(--rt-color-danger-100) 18%, #1c1b1e)),
+    bg-accent-danger-solid: var(--rt-color-danger-100),
+    bg-accent-danger-hover: t(
+            color-mix(in srgb, var(--rt-color-danger-100) 90%, #000),
+            color-mix(in srgb, var(--rt-color-danger-100) 90%, #fff)
+        ),
+    bg-accent-danger-disabled: color-mix(in srgb, var(--rt-color-danger-100) 38%, transparent),
+    bg-accent-info-subtle: t(var(--rt-color-info-20), color-mix(in srgb, var(--rt-color-info-100) 18%, #1c1b1e)),
+    bg-accent-info-solid: var(--rt-color-info-100),
+    bg-accent-info-hover: t(color-mix(in srgb, var(--rt-color-info-100) 90%, #000), color-mix(in srgb, var(--rt-color-info-100) 90%, #fff)),
+    bg-accent-info-disabled: color-mix(in srgb, var(--rt-color-info-100) 38%, transparent),
     bg-accent-neutral-subtle: t(#f3f3f3, rgb(255 255 255 / 6%)),
     bg-accent-neutral-solid: t(#747474, #a3a3a3),
     bg-accent-neutral-hover: t(#a3a3a3, #747474),
@@ -160,41 +214,41 @@ $semantic: (
     text-base-inverse: t(#fff, #181818, inverse-on-surface),
     /* ---- text / static ---- */ text-static-light: #fff,
     text-static-dark: #181818,
-    /* ---- text / accent ---- */ text-accent-brand: t(#0d1c2b, #e8e8e8, primary),
-    text-accent-primary: t(#4284d7, #6d96e8, primary),
-    text-accent-success: #01af8d,
-    text-accent-success-soft: #21b18e,
-    text-accent-warning: #ef7128,
-    text-accent-warning-soft: #ee7a34,
-    text-accent-danger: t(#eb5055, #eb5055, error),
-    text-accent-danger-soft: #e88487,
-    text-accent-info: #4284d7,
-    text-accent-info-soft: #4285f4,
+    /* ---- text / accent ---- */ text-accent-brand: t(var(--rt-color-brand-100), var(--rt-color-brand-20)),
+    text-accent-primary: t(var(--rt-color-primary-100), var(--rt-color-primary-60)),
+    text-accent-success: var(--rt-color-success-100),
+    text-accent-success-soft: var(--rt-color-success-80),
+    text-accent-warning: var(--rt-color-warning-100),
+    text-accent-warning-soft: var(--rt-color-warning-80),
+    text-accent-danger: var(--rt-color-danger-100),
+    text-accent-danger-soft: var(--rt-color-danger-60),
+    text-accent-info: var(--rt-color-info-100),
+    text-accent-info-soft: var(--rt-color-info-80),
     /* ---- icon / neutral (adaptive) ---- */ icon-neutral-default: t(#323033, #e0e0e0),
     icon-neutral-soft: t(#747474, #a3a3a3),
     icon-neutral-disabled: t(#a3a3a3, #747474),
     icon-neutral-inverse: t(#fff, #181818),
     /* ---- icon / static ---- */ icon-static-light: #fff,
     icon-static-dark: #181818,
-    /* ---- icon / accent ---- */ icon-accent-brand: t(#0d1c2b, #e8e8e8, primary),
-    icon-accent-primary: t(#4284d7, #6d96e8, primary),
-    icon-accent-success: #01af8d,
-    icon-accent-warning: #ef7128,
-    icon-accent-danger: t(#eb5055, #eb5055, error),
-    icon-accent-info: #4284d7,
+    /* ---- icon / accent ---- */ icon-accent-brand: t(var(--rt-color-brand-100), var(--rt-color-brand-20)),
+    icon-accent-primary: t(var(--rt-color-primary-100), var(--rt-color-primary-60)),
+    icon-accent-success: var(--rt-color-success-100),
+    icon-accent-warning: var(--rt-color-warning-100),
+    icon-accent-danger: var(--rt-color-danger-100),
+    icon-accent-info: var(--rt-color-info-100),
     /* ---- border / neutral (adaptive) ---- */ border-neutral-subtle: t(#e8e8e8, #2e2d31),
     border-neutral-default: t(#e0e0e0, #3f3e43, outline-variant),
     border-neutral-medium: t(#d1d1d1, #4a494e),
     border-neutral-divider: t(#ccc, #4a494e),
     border-neutral-strong: t(#a3a3a3, #5c5b60, outline),
     border-neutral-emphasis: t(#747474, #a3a3a3),
-    /* ---- border / accent ---- */ border-accent-primary: t(#4284d7, #6d96e8, primary),
-    border-accent-success: #01af8d,
-    border-accent-warning: #ef7128,
-    border-accent-danger: t(#eb5055, #eb5055, error),
-    border-accent-danger-soft: #e88487,
-    border-accent-info: #4284d7,
-    border-focus: t(#b3ceef, #6d96e8),
+    /* ---- border / accent ---- */ border-accent-primary: t(var(--rt-color-primary-100), var(--rt-color-primary-60)),
+    border-accent-success: var(--rt-color-success-100),
+    border-accent-warning: var(--rt-color-warning-100),
+    border-accent-danger: var(--rt-color-danger-100),
+    border-accent-danger-soft: var(--rt-color-danger-60),
+    border-accent-info: var(--rt-color-info-100),
+    border-focus: t(var(--rt-color-primary-40), var(--rt-color-primary-60)),
     /* ---- form controls (rt extension) ---- */ control-track: t(#e8e8e8, #4a494e),
     control-thumb: t(#fff, #eee),
     control-checked: t(#323033, #e0e0e0),
@@ -306,6 +360,13 @@ $breakpoint: (
     @each $a in $overlay-steps {
         --rt-color-dark-a#{$a}: rgba(24, 24, 24, #{calc($a / 100)});
         --rt-color-light-a#{$a}: rgba(255, 255, 255, #{calc($a / 100)});
+    }
+
+    // accent-role ramps (indirection layer) — overridable per color scheme
+    @each $role, $tones in $accent-roles {
+        @each $step, $value in $tones {
+            --rt-color-#{$role}-#{$step}: #{$value};
+        }
     }
 
     /* --- Tier 2: semantic --- */

--- a/projects/ui-kit/src/styles/base/_variables.scss
+++ b/projects/ui-kit/src/styles/base/_variables.scss
@@ -1,10 +1,8 @@
 /* Material Theme */
 $main-theme: light;
-$styles-clr-prefix: 'clr';
 $styles-prefix: 'rt';
 
 /* Base */
-$avalon-color: var(--clr-avalon);
 $base-accent: var(--rt-text-accent-brand);
 
 /* Device Definitions */
@@ -20,13 +18,11 @@ $base-font-weight: 400;
 $base-font-size: 1rem;
 $base-text-color: var(--rt-text-base-primary);
 
-/* Colors */
-$clr-red-100: #eb5055;
-$clr-red-10: #fdedee;
-$clr-green-80: #00b894;
-$clr-green-10: #e5f8f4;
+/* Button palette seeds (static — fed to sass color.scale() for hover/active states) */
+$btn-danger: #eb5055;
+$btn-danger-soft: #fdedee;
+$btn-success: #00b894; // outlier: not on the --rt-color-green scale
+$btn-success-soft: #e5f8f4;
 
 /* Components */
-$side-panel-dynamic-clr: var(--rt-text-accent-brand);
-$pagination-dynamic-clr: var(--rt-text-accent-brand);
 $text-highlight-color: #0077bf;

--- a/projects/ui-kit/src/styles/base/_variables.scss
+++ b/projects/ui-kit/src/styles/base/_variables.scss
@@ -1,6 +1,5 @@
 /* Material Theme */
 $main-theme: light;
-
 $styles-clr-prefix: 'clr';
 $styles-prefix: 'rt';
 
@@ -24,7 +23,6 @@ $base-text-color: var(--rt-text-base-primary);
 /* Colors */
 $clr-red-100: #eb5055;
 $clr-red-10: #fdedee;
-
 $clr-green-80: #00b894;
 $clr-green-10: #e5f8f4;
 

--- a/projects/ui-kit/src/styles/color-scheme.spec.ts
+++ b/projects/ui-kit/src/styles/color-scheme.spec.ts
@@ -1,0 +1,198 @@
+import * as path from 'path';
+import * as sass from 'sass';
+
+/**
+ * Build-time guarantees for the custom color-scheme mechanism:
+ *   1. Δ0 — moving the accent tier onto the `--rt-color-{role}-{N}` indirection
+ *      keeps every accent semantic token byte-for-byte identical (own palette).
+ *   2. The `rt.color-scheme` Sass mixin emits a scoped `[data-rt-scheme]` block.
+ *   3. Input validation rejects unknown roles / out-of-range tones.
+ *   4. The Avalon teal case: a teal ramp drives `--rt-bg-accent-primary-solid` to teal.
+ */
+
+const STYLES_DIR: string = __dirname;
+
+/** Frozen resolved (own-palette) values of every accent token BEFORE the indirection refactor. */
+const BASELINE: Record<string, string> = {
+    '--rt-bg-accent-primary-subtle': 'light-dark(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e))',
+    '--rt-bg-accent-primary-solid': '#4284d7',
+    '--rt-bg-accent-primary-hover': 'light-dark(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff))',
+    '--rt-bg-accent-primary-disabled': 'color-mix(in srgb, #4284d7 38%, transparent)',
+    '--rt-bg-accent-success-subtle': 'light-dark(#e5f8f4, color-mix(in srgb, #01af8d 18%, #1c1b1e))',
+    '--rt-bg-accent-success-solid': '#21b18e',
+    '--rt-bg-accent-success-hover': 'light-dark(color-mix(in srgb, #21b18e 90%, #000), color-mix(in srgb, #21b18e 90%, #fff))',
+    '--rt-bg-accent-success-disabled': 'color-mix(in srgb, #21b18e 38%, transparent)',
+    '--rt-bg-accent-warning-subtle': 'light-dark(#e8cbbf, color-mix(in srgb, #ef7128 18%, #1c1b1e))',
+    '--rt-bg-accent-warning-solid': '#ee7a34',
+    '--rt-bg-accent-warning-hover': 'light-dark(color-mix(in srgb, #ee7a34 90%, #000), color-mix(in srgb, #ee7a34 90%, #fff))',
+    '--rt-bg-accent-warning-disabled': 'color-mix(in srgb, #ee7a34 38%, transparent)',
+    '--rt-bg-accent-danger-subtle': 'light-dark(#fdedee, color-mix(in srgb, #eb5055 18%, #1c1b1e))',
+    '--rt-bg-accent-danger-solid': '#eb5055',
+    '--rt-bg-accent-danger-hover': 'light-dark(color-mix(in srgb, #eb5055 90%, #000), color-mix(in srgb, #eb5055 90%, #fff))',
+    '--rt-bg-accent-danger-disabled': 'color-mix(in srgb, #eb5055 38%, transparent)',
+    '--rt-bg-accent-info-subtle': 'light-dark(#eaedfc, color-mix(in srgb, #4284d7 18%, #1c1b1e))',
+    '--rt-bg-accent-info-solid': '#4284d7',
+    '--rt-bg-accent-info-hover': 'light-dark(color-mix(in srgb, #4284d7 90%, #000), color-mix(in srgb, #4284d7 90%, #fff))',
+    '--rt-bg-accent-info-disabled': 'color-mix(in srgb, #4284d7 38%, transparent)',
+    '--rt-text-accent-brand': 'light-dark(#0d1c2b, #e8e8e8)',
+    '--rt-text-accent-primary': 'light-dark(#4284d7, #6d96e8)',
+    '--rt-text-accent-success': '#01af8d',
+    '--rt-text-accent-success-soft': '#21b18e',
+    '--rt-text-accent-warning': '#ef7128',
+    '--rt-text-accent-warning-soft': '#ee7a34',
+    '--rt-text-accent-danger': '#eb5055',
+    '--rt-text-accent-danger-soft': '#e88487',
+    '--rt-text-accent-info': '#4284d7',
+    '--rt-text-accent-info-soft': '#4285f4',
+    '--rt-icon-accent-brand': 'light-dark(#0d1c2b, #e8e8e8)',
+    '--rt-icon-accent-primary': 'light-dark(#4284d7, #6d96e8)',
+    '--rt-icon-accent-success': '#01af8d',
+    '--rt-icon-accent-warning': '#ef7128',
+    '--rt-icon-accent-danger': '#eb5055',
+    '--rt-icon-accent-info': '#4284d7',
+    '--rt-border-accent-primary': 'light-dark(#4284d7, #6d96e8)',
+    '--rt-border-accent-success': '#01af8d',
+    '--rt-border-accent-warning': '#ef7128',
+    '--rt-border-accent-danger': '#eb5055',
+    '--rt-border-accent-danger-soft': '#e88487',
+    '--rt-border-accent-info': '#4284d7',
+    '--rt-border-focus': 'light-dark(#b3ceef, #6d96e8)',
+};
+
+/** Resolve `var(--mat-sys-X, FALLBACK)` to its fallback (own-palette, no Material configured). */
+function stripMat(input: string): string {
+    let value: string = input;
+    let index: number = value.indexOf('var(--mat-sys-');
+
+    while (index >= 0) {
+        let depth: number = 0;
+        let j: number = index + 4;
+
+        for (; j < value.length; j++) {
+            if (value[j] === '(') {
+                depth++;
+            } else if (value[j] === ')') {
+                if (depth === 0) {
+                    break;
+                }
+                depth--;
+            }
+        }
+
+        const inner: string = value.slice(index + 4, j);
+        const comma: number = inner.indexOf(',');
+        value = value.slice(0, index) + inner.slice(comma + 1).trim() + value.slice(j + 1);
+        index = value.indexOf('var(--mat-sys-');
+    }
+
+    return value;
+}
+
+/** Collapse `light-dark(X, X)` to `X` (identical branches render the same in both modes). */
+function normalize(input: string): string {
+    let value: string = input.replace(/\s+/g, ' ').trim();
+    let prev: string = '';
+
+    while (value !== prev) {
+        prev = value;
+        value = value.replace(/light-dark\(\s*([^,()]+?)\s*,\s*\1\s*\)/g, '$1');
+    }
+
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+/** Extract `--name: value;` declarations matching a name pattern from compiled CSS. */
+function extractDeclarations(css: string, namePattern: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    const re: RegExp = new RegExp(`(${namePattern}):\\s*([^;]+);`, 'g');
+    let match: RegExpExecArray | null = re.exec(css);
+
+    while (match !== null) {
+        out[match[1]] = match[2].trim();
+        match = re.exec(css);
+    }
+
+    return out;
+}
+
+function compileTokens(): string {
+    return sass.compile(path.join(STYLES_DIR, 'tokens.scss')).css;
+}
+
+function compileWithMixin(body: string): sass.CompileResult {
+    return sass.compileString(`@use 'main' as rt;\n${body}`, { loadPaths: [STYLES_DIR] });
+}
+
+describe('rt-tools color schemes', () => {
+    describe('Δ0 regression — accent indirection keeps the own palette byte-for-byte', () => {
+        it('every accent semantic token resolves to its pre-refactor value', () => {
+            const css: string = compileTokens();
+            const ramp: Record<string, string> = extractDeclarations(css, '--rt-color-(?:primary|info|success|warning|danger|brand)-\\d+');
+            const semantic: Record<string, string> = extractDeclarations(
+                css,
+                '--rt-(?:bg|text|icon|border)-accent[\\w-]*|--rt-border-focus'
+            );
+
+            const resolveRamp: (value: string) => string = (value: string): string => {
+                let resolved: string = value;
+                let prev: string = '';
+
+                while (resolved !== prev) {
+                    prev = resolved;
+                    for (const key of Object.keys(ramp)) {
+                        resolved = resolved.split(`var(${key})`).join(stripMat(ramp[key]));
+                    }
+                }
+
+                return normalize(stripMat(resolved));
+            };
+
+            for (const token of Object.keys(BASELINE)) {
+                expect(semantic[token]).toBeDefined();
+                expect(resolveRamp(semantic[token])).toBe(BASELINE[token]);
+            }
+        });
+    });
+
+    describe('rt.color-scheme mixin', () => {
+        it('emits a scoped [data-rt-scheme] block with only raw role rows', () => {
+            const css: string = compileWithMixin(
+                '@include rt.color-scheme(\'teal\', (primary: (20: #b3e3e1, 100: #008582), brand: (100: #008582)));'
+            ).css;
+
+            const block: string = css.slice(css.indexOf('[data-rt-scheme=teal]'));
+
+            expect(block).toContain('[data-rt-scheme=teal]');
+            expect(block).toContain('--rt-color-primary-100: #008582');
+            expect(block).toContain('--rt-color-primary-20: #b3e3e1');
+            expect(block).toContain('--rt-color-brand-100: #008582');
+            // schemes never duplicate the semantic derivation layer
+            expect(block).not.toContain('--rt-bg-accent-primary-solid:');
+        });
+
+        it('rejects an unknown role', () => {
+            expect(() => compileWithMixin('@include rt.color-scheme(\'x\', (foo: (100: #000000)));')).toThrow(/unknown role/i);
+        });
+
+        it('rejects an out-of-range tone', () => {
+            expect(() => compileWithMixin('@include rt.color-scheme(\'x\', (primary: (150: #000000)));')).toThrow(/integer 0–100/i);
+        });
+
+        it('rejects an empty role map', () => {
+            expect(() => compileWithMixin('@include rt.color-scheme(\'x\', ());')).toThrow(/non-empty map/i);
+        });
+    });
+
+    describe('Avalon teal reference case', () => {
+        it('a teal primary ramp recolors --rt-bg-accent-primary-solid to teal', () => {
+            const css: string = compileWithMixin(
+                '@include rt.color-scheme(\'teal\', (primary: (20: #b3e3e1, 40: #5cb8b5, 60: #1a9d99, 100: #008582)));'
+            ).css;
+
+            const scheme: Record<string, string> = extractDeclarations(css, '--rt-color-primary-\\d+');
+            // bg-accent-primary-solid === var(--rt-color-primary-100); under the teal scheme that is #008582
+            expect(scheme['--rt-color-primary-100']).toBe('#008582');
+            expect(normalize(stripMat(css.match(/--rt-bg-accent-primary-solid:\s*([^;]+);/)![1]))).toBe('var(--rt-color-primary-100)');
+        });
+    });
+});

--- a/projects/ui-kit/src/styles/color-scheme.spec.ts
+++ b/projects/ui-kit/src/styles/color-scheme.spec.ts
@@ -7,7 +7,7 @@ import * as sass from 'sass';
  *      keeps every accent semantic token byte-for-byte identical (own palette).
  *   2. The `rt.color-scheme` Sass mixin emits a scoped `[data-rt-scheme]` block.
  *   3. Input validation rejects unknown roles / out-of-range tones.
- *   4. The Avalon teal case: a teal ramp drives `--rt-bg-accent-primary-solid` to teal.
+ *   4. The teal case: a custom teal ramp drives `--rt-bg-accent-primary-solid` to teal.
  */
 
 const STYLES_DIR: string = __dirname;
@@ -221,7 +221,7 @@ describe('rt-tools color schemes', () => {
         });
     });
 
-    describe('Avalon teal reference case', () => {
+    describe('teal reference case', () => {
         it('a teal primary ramp recolors --rt-bg-accent-primary-solid to teal', () => {
             const css: string = compileWithMixin(
                 '@include rt.color-scheme(\'teal\', (primary: (20: #b3e3e1, 40: #5cb8b5, 60: #1a9d99, 100: #008582)));'

--- a/projects/ui-kit/src/styles/color-scheme.spec.ts
+++ b/projects/ui-kit/src/styles/color-scheme.spec.ts
@@ -154,6 +154,44 @@ describe('rt-tools color schemes', () => {
         });
     });
 
+    describe('Material hybrid — default honors --mat-sys-*, a scheme overrides it', () => {
+        it('default ramp tones carry the --mat-sys-* fallback where the original token did', () => {
+            const ramp: Record<string, string> = extractDeclarations(
+                compileTokens(),
+                '--rt-color-(?:primary|info|success|warning|danger|brand)-\\d+'
+            );
+
+            // tones that mapped to a Material system color carry the fallback (default honors Material)
+            expect(ramp['--rt-color-primary-100']).toBe('var(--mat-sys-primary, #4284d7)');
+            expect(ramp['--rt-color-primary-20']).toBe('var(--mat-sys-primary-container, #eaedfc)');
+            expect(ramp['--rt-color-danger-100']).toBe('var(--mat-sys-error, #eb5055)');
+            expect(ramp['--rt-color-brand-100']).toBe('var(--mat-sys-primary, #0d1c2b)');
+
+            // roles with no Material mapping stay raw — and a scheme overriding ANY tone with a raw
+            // value drops the fallback entirely, so the scheme wins over an active Material theme.
+            expect(ramp['--rt-color-info-100']).toBe('#4284d7');
+            expect(ramp['--rt-color-success-100']).toBe('#01af8d');
+            expect(ramp['--rt-color-warning-100']).toBe('#ef7128');
+        });
+    });
+
+    describe('dark mode — a scheme drives both modes via distinct ramp tones', () => {
+        it('accent tokens pick tone-100 in light and tone-60 in dark (scheme controls each)', () => {
+            const semantic: Record<string, string> = extractDeclarations(
+                compileTokens(),
+                '--rt-text-accent-primary|--rt-border-accent-primary|--rt-icon-accent-primary'
+            );
+
+            // light-dark(primary-100, primary-60): the kit fixes WHICH tone per mode; the scheme
+            // supplies the VALUE of each tone → a scheme can set a different dark tone (tone-60) than light.
+            for (const token of Object.keys(semantic)) {
+                expect(semantic[token]).toContain('var(--rt-color-primary-100)');
+                expect(semantic[token]).toContain('var(--rt-color-primary-60)');
+                expect(semantic[token].indexOf('primary-100')).toBeLessThan(semantic[token].indexOf('primary-60'));
+            }
+        });
+    });
+
     describe('rt.color-scheme mixin', () => {
         it('emits a scoped [data-rt-scheme] block with only raw role rows', () => {
             const css: string = compileWithMixin(

--- a/projects/ui-kit/src/styles/components/_button.scss
+++ b/projects/ui-kit/src/styles/components/_button.scss
@@ -1,5 +1,5 @@
 /// @deprecated — legacy `.c-button` system. New code uses `.rtui-btn` (_rtui_button.scss);
-/// ~60% of this module duplicates it. Kept because consumers (Avalon) still apply `.c-button`
+/// ~60% of this module duplicates it. Kept because consumers still apply `.c-button`
 /// classes AND override `--rt-button-*` vars directly (incl. dark mode) — rerouting these rules
 /// onto `--rt-rtui-btn-*` would silently kill those overrides. Removal plan (next major):
 /// map classes `--fill-green→success`, `--fill-red→error`, `--fill-blue→accent-light`,
@@ -27,7 +27,8 @@ $button: (
         background: var(--rt-color-neutral-25),
     ),
     text-active: (
-        background: var(--clr-black-30),
+        background: #b2cbca,
+        // palette outlier, no neutral-scale equivalent
     ),
     text-base: (
         color: var(--rt-color-neutral-60),
@@ -64,36 +65,36 @@ $button: (
         color: var(--rt-color-neutral-0),
     ),
     fill-green: (
-        border: 1px solid color.scale(vars.$clr-green-80, $lightness: -10%),
+        border: 1px solid color.scale(vars.$btn-success, $lightness: -10%),
         color: var(--rt-color-neutral-0),
         background-color: var(--rt-color-green-80),
     ),
     fill-green-hover: (
-        background-color: color.scale(vars.$clr-green-80, $lightness: -10%),
+        background-color: color.scale(vars.$btn-success, $lightness: -10%),
     ),
     fill-green-light: (
-        border-color: color.scale(vars.$clr-green-10, $lightness: -10%),
+        border-color: color.scale(vars.$btn-success-soft, $lightness: -10%),
         color: var(--rt-color-green-100),
         background-color: var(--rt-color-green-10),
     ),
     fill-green-light-hover: (
-        background-color: color.scale(vars.$clr-green-10, $lightness: -10%),
+        background-color: color.scale(vars.$btn-success-soft, $lightness: -10%),
     ),
     fill-red: (
-        border: 1px solid color.scale(vars.$clr-red-100, $lightness: -10%),
+        border: 1px solid color.scale(vars.$btn-danger, $lightness: -10%),
         color: var(--rt-color-neutral-0),
-        background-color: vars.$clr-red-100,
+        background-color: vars.$btn-danger,
     ),
     fill-red-hover: (
-        background-color: color.scale(vars.$clr-red-100, $lightness: -10%),
+        background-color: color.scale(vars.$btn-danger, $lightness: -10%),
     ),
     fill-red-light: (
-        border-color: color.scale(vars.$clr-red-10, $lightness: -10%),
+        border-color: color.scale(vars.$btn-danger-soft, $lightness: -10%),
         color: var(--rt-color-red-100),
         background-color: var(--rt-color-red-10),
     ),
     fill-red-light-hover: (
-        background-color: color.scale(vars.$clr-red-10, $lightness: -10%),
+        background-color: color.scale(vars.$btn-danger-soft, $lightness: -10%),
     ),
     outline: (
         border: 1px solid var(--rt-color-blue-40),

--- a/projects/ui-kit/src/styles/components/_button.scss
+++ b/projects/ui-kit/src/styles/components/_button.scss
@@ -1,3 +1,10 @@
+/// @deprecated — legacy `.c-button` system. New code uses `.rtui-btn` (_rtui_button.scss);
+/// ~60% of this module duplicates it. Kept because consumers (Avalon) still apply `.c-button`
+/// classes AND override `--rt-button-*` vars directly (incl. dark mode) — rerouting these rules
+/// onto `--rt-rtui-btn-*` would silently kill those overrides. Removal plan (next major):
+/// map classes `--fill-green→success`, `--fill-red→error`, `--fill-blue→accent-light`,
+/// `--outline-*→*-outline`; `--txt-*`/`--fab` first need a text/icon appearance in .rtui-btn.
+/// See TOKENS.md "Buttons: legacy vs rtui".
 @use '../base/mixin' as mixins;
 @use '../base/variables' as vars;
 @use 'sass:color' as color;
@@ -112,22 +119,22 @@ $button: (
 }
 
 button {
-    line-height: 1;
     cursor: pointer;
+    line-height: 1;
 }
 
 .c-button {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    font-family: var(--rt-button-base-font-family);
-    line-height: 1;
-    position: relative;
     justify-content: center;
-    font-size: 1rem;
     color: var(--rt-button-base-color);
+    font-family: var(--rt-button-base-font-family);
+    font-size: 1rem;
+    line-height: 1;
     transition: all 0.15s linear;
 
-    //FAB
+    // FAB
     &[class*='--fab'] {
         border: 0;
         background-color: transparent;
@@ -149,8 +156,8 @@ button {
     // TEXT
     &[class*='--txt-'] {
         border: 0;
-        background-color: transparent;
         border-radius: 5px;
+        background-color: transparent;
 
         &:hover {
             background: var(--rt-button-text-hover-background);
@@ -239,9 +246,9 @@ button {
         &[class*='green'] {
             border: var(--rt-button-fill-green-border);
             border-radius: 2px;
-            color: var(--rt-button-fill-green-color);
-            box-shadow: 0 2px 4px rgba(24, 24, 24, 0.1);
             background-color: var(--rt-button-fill-green-background-color);
+            box-shadow: 0 2px 4px rgb(24 24 24 / 10%);
+            color: var(--rt-button-fill-green-color);
 
             &:hover {
                 background-color: var(--rt-button-fill-green-hover-background-color);
@@ -249,8 +256,8 @@ button {
 
             &[class*='-light'] {
                 border-color: var(--rt-button-fill-green-light-border-color);
-                color: var(--rt-button-fill-green-light-color);
                 background-color: var(--rt-button-fill-green-light-background-color);
+                color: var(--rt-button-fill-green-light-color);
 
                 &:hover {
                     background-color: var(--rt-button-fill-green-light-hover-background-color);
@@ -261,9 +268,9 @@ button {
         &[class*='red'] {
             border: var(--rt-button-fill-red-border);
             border-radius: 2px;
-            color: var(--rt-button-fill-red-color);
-            box-shadow: 0 2px 4px rgba(24, 24, 24, 0.1);
             background-color: var(--rt-button-fill-red-background-color);
+            box-shadow: 0 2px 4px rgb(24 24 24 / 10%);
+            color: var(--rt-button-fill-red-color);
 
             &:hover {
                 background-color: var(--rt-button-fill-red-hover-background-color);
@@ -271,8 +278,8 @@ button {
 
             &[class*='-light'] {
                 border-color: var(--rt-button-fill-red-light-border-color);
-                color: var(--rt-button-fill-red-light-color);
                 background-color: var(--rt-button-fill-red-light-background-color);
+                color: var(--rt-button-fill-red-light-color);
 
                 &:hover {
                     background-color: var(--rt-button-fill-red-light-hover-background-color);
@@ -348,7 +355,7 @@ button {
 
     // SHADOW
     &[class*='--shadow'] {
-        box-shadow: 0 2px 4px rgba(24, 24, 24, 0.1);
+        box-shadow: 0 2px 4px rgb(24 24 24 / 10%);
     }
 
     // --shadow

--- a/projects/ui-kit/src/styles/components/_dynamic-selectors.scss
+++ b/projects/ui-kit/src/styles/components/_dynamic-selectors.scss
@@ -46,15 +46,14 @@ $dynamic-selector: (
 
 .rtui-dynamic-selector {
     &__item {
-        height: var(--rt-dynamic-selector-item-height);
         display: flex;
-        justify-content: flex-start;
+        height: var(--rt-dynamic-selector-item-height);
         align-items: center;
-
-        background-color: var(--rt-dynamic-selector-item-background-color);
+        justify-content: flex-start;
+        padding: var(--rt-dynamic-selector-item-padding);
         border-radius: var(--rt-dynamic-selector-item-border-radius);
         margin-bottom: var(--rt-dynamic-selector-item-margin-bottom);
-        padding: var(--rt-dynamic-selector-item-padding);
+        background-color: var(--rt-dynamic-selector-item-background-color);
 
         &::-webkit-scrollbar {
             display: none;
@@ -66,17 +65,17 @@ $dynamic-selector: (
 
         &-mover {
             display: flex;
-            justify-content: center;
             align-items: center;
+            justify-content: center;
             padding: var(--rt-dynamic-selector-item-mover-padding);
             border-right: var(--rt-dynamic-selector-item-mover-border-right);
             margin-right: var(--rt-dynamic-selector-item-mover-margin-right);
         }
 
         &-title {
-            white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         &-input {
@@ -92,11 +91,11 @@ $dynamic-selector: (
 
         &-control {
             display: flex;
-            justify-content: center;
             align-items: center;
-            gap: var(--rt-dynamic-selector-item-control-gap);
+            justify-content: center;
             padding: var(--rt-dynamic-selector-item-control-padding);
             border-right: var(--rt-dynamic-selector-item-control-border-right);
+            gap: var(--rt-dynamic-selector-item-control-gap);
 
             &:last-child {
                 padding: var(--rt-dynamic-selector-item-control-last-child-padding);
@@ -105,8 +104,8 @@ $dynamic-selector: (
 
             &-button {
                 display: flex;
-                justify-content: center;
                 align-items: center;
+                justify-content: center;
 
                 .mat-icon {
                     width: var(--rt-dynamic-selector-item-control-icon-size);

--- a/projects/ui-kit/src/styles/components/_form.scss
+++ b/projects/ui-kit/src/styles/components/_form.scss
@@ -3,30 +3,28 @@
 
 // FORM
 .c-form {
-    width: 100%;
-
     display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
+    width: 100%;
     flex: 1 1 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
 
     &__title {
         font-size: 1.5rem;
-        line-height: 1.1;
         font-weight: 600;
+        line-height: 1.1;
     }
 
     &__title-descr {
         margin-top: 0.75rem;
-        font-size: 1rem;
         color: var(--rt-text-base-secondary);
+        font-size: 1rem;
     }
 
     &__item {
-        width: 100%;
-
         display: flex;
+        width: 100%;
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
@@ -38,18 +36,15 @@
 
     &__controls {
         position: relative;
-        width: 100%;
-
         display: flex;
+        width: 100%;
         flex-direction: column;
-
         margin-top: 2rem;
     }
 
     &__control-item {
-        width: 100%;
-
         display: flex;
+        width: 100%;
         align-items: center;
         justify-content: flex-start;
 

--- a/projects/ui-kit/src/styles/components/_material-bridge.scss
+++ b/projects/ui-kit/src/styles/components/_material-bridge.scss
@@ -1,0 +1,30 @@
+/// Material bridge — the single global touch-point between rt-tools and Angular Material.
+///
+/// Rule: every GLOBAL override of Material internals (--mat-* / --mdc-* vars, .mat-* / .cdk-* selectors
+/// that is not scoped to a component's own DOM) lives here, so a Material upgrade is reviewed in one file.
+///
+/// Scoped piercings stay next to their component (they target Material nodes inside the component's
+/// own template) — current inventory, revisit on every Angular Material major:
+///   - snack-bar:            styles/components/_snackbar.scss (panelClass .snack-bar-*: --mat-snack-bar-*, --mdc-snackbar-*)
+///   - table:                styles/components/_table.scss (consumes --mat-form-field-filled-container-color)
+///   - checkbox:             styles/components/_checkbox.scss (consumes --mat-button-text-label-text-color)
+///   - dynamic-selectors:    styles/components/_dynamic-selectors.scss (+ ::ng-deep .mat-mdc-form-field-* in
+///                           multi-selector-popup / selected-list component scss)
+///   - side-menu:            menu-sub-item component scss (::ng-deep .mat-expansion-*)
+///   - modal:                modal.component.scss (::ng-deep .mat-icon)
+///   - spinner:              spinner.component.scss (::ng-deep circle of mat-spinner SVG)
+///   - aside:                aside-panel.component.scss (.mat-mdc-tab-header, .mat-badge-content — encapsulation: None)
+///   - toolbar:              toolbar.component.scss (--mat-tab-*, --mdc-secondary-navigation-tab-*)
+
+/* Keep CDK overlays (aside drawer, selector popups, modals) above app chrome.
+   Moved from aside-panel.component.scss — applies app-wide by design. */
+.cdk-overlay-container,
+.cdk-overlay-pane {
+    z-index: 9999;
+}
+
+/* Mat tab groups stretch to their container (aside tabs rely on it).
+   Moved from aside-panel.component.scss. */
+.mat-mdc-tab-group {
+    width: 100%;
+}

--- a/projects/ui-kit/src/styles/components/_rtui_button.scss
+++ b/projects/ui-kit/src/styles/components/_rtui_button.scss
@@ -171,27 +171,27 @@ $rtui-button: (
     --shadow: var(--rt-rtui-btn-base-shadow);
     --shadow-blur: var(--rt-rtui-btn-base-shadow-blur);
 
+    display: var(--display);
     width: var(--width);
     align-items: center;
-    background-color: var(--bg);
+    justify-content: center;
+    padding: var(--padding);
     border: var(--border);
     border-radius: 6px;
+    background-color: var(--bg);
     box-shadow: var(--shadow);
     color: var(--color);
     cursor: pointer;
-    display: var(--display);
     font-size: var(--font-size);
     font-weight: 600;
     gap: var(--gap);
-    justify-content: center;
     line-height: 1;
-    padding: var(--padding);
+    text-decoration: none;
     transition:
         background-color 0.15s linear,
         color 0.15s linear,
         box-shadow 0.15s linear,
         border-color 0.15s linear;
-    text-decoration: none;
 
     &:focus {
         outline: none;

--- a/projects/ui-kit/src/styles/components/_table.scss
+++ b/projects/ui-kit/src/styles/components/_table.scss
@@ -63,24 +63,20 @@ $table: (
     // initial table container scrollbar styles
     --rt-table-container-content-scrollbar-vertical-width: 0;
     --rt-table-container-content-scrollbar-horizontal-height: 12px;
-
     --rt-table-row-border-bottom-width: 1px;
     --rt-table-header-cell-wrapper-border-width: 1px;
 }
 
 // TABLE
 .c-table {
+    overflow: scroll;
     width: 100%;
-
     border-collapse: collapse;
-
-    overflow-x: scroll;
-    overflow-y: scroll;
 
     thead {
         position: sticky;
-        top: 0;
         z-index: var(--rt-table-header-z-index);
+        top: 0;
         font-size: var(--rt-table-header-font-size);
 
         tr {
@@ -91,12 +87,12 @@ $table: (
             th {
                 background-color: color-mix(in srgb, var(--rt-table-header-background-color), var(--rt-bg-base-base) 50%);
 
-                &:not(.c-table__cell--filterable):not(.c-table__cell--empty) {
+                &:not(.c-table__cell--filterable, .c-table__cell--empty) {
                     background-color: var(--rt-table-header-background-color);
                 }
 
                 &:hover {
-                    &:not(.c-table__cell--selectable):not(.c-table__cell--filterable) {
+                    &:not(.c-table__cell--selectable, .c-table__cell--filterable) {
                         background-color: color-mix(in srgb, var(--rt-table-header-background-color), var(--rt-bg-base-base) 30%);
                     }
                 }
@@ -105,18 +101,17 @@ $table: (
     }
 
     tbody {
-        font-size: var(--rt-table-body-font-size);
         background-color: var(--rt-table-body-background-color);
+        font-size: var(--rt-table-body-font-size);
     }
 }
 
 // ROW
 .c-table__row {
     height: var(--rt-table-row-height);
-    color: var(--rt-table-row-color);
     border-bottom: var(--rt-table-row-border-bottom);
     background-color: var(--rt-table-row-background-color);
-
+    color: var(--rt-table-row-color);
     transform: translate(0);
 
     &--active {
@@ -139,20 +134,17 @@ $table: (
 
 // CELL
 th.c-table__cell {
+    position: relative;
     width: fit-content;
     height: 100%;
-
-    position: relative;
-
-    pointer-events: none;
-
     padding: var(--rt-table-header-cell-wrapper-padding);
+    background-color: var(--rt-table-header-cell-wrapper-background-color);
     color: var(--rt-table-header-cell-wrapper-text-color);
     font-size: var(--rt-table-header-cell-wrapper-font-size);
     font-weight: var(--rt-table-header-cell-wrapper-font-weight);
-    text-align: var(--rt-table-header-cell-wrapper-text-align);
     line-height: var(--rt-table-header-cell-wrapper-line-height);
-    background-color: var(--rt-table-header-cell-wrapper-background-color);
+    pointer-events: none;
+    text-align: var(--rt-table-header-cell-wrapper-text-align);
 
     &--sortable,
     &--selectable,
@@ -164,14 +156,14 @@ th.c-table__cell {
         padding: var(--rt-table-header-filterable-cell-wrapper-padding);
     }
 
-    &:not(:last-child):not(&--selectable):not(&--empty) {
-        &::after {
-            content: '';
+    &:not(:last-child, &--selectable, &--empty) {
+        &:after {
             position: absolute;
-            right: 0;
             top: 25%;
+            right: 0;
             height: 50%;
             border-right: var(--rt-table-header-cell-wrapper-border-right);
+            content: '';
             pointer-events: none;
         }
     }
@@ -180,41 +172,32 @@ th.c-table__cell {
 td.c-table__cell {
     width: fit-content;
     height: 100%;
-
     padding: var(--rt-table-base-cell-wrapper-padding);
 }
 
 // ROW ACTIONS
 .c-table-actions {
+    position: absolute;
+    z-index: var(--rt-table-actions-z-index);
+    top: 0;
+    right: 0;
+    display: flex;
     width: 100%;
     height: var(--rt-table-row-height);
-
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: var(--rt-table-actions-z-index);
-
-    display: flex;
-    justify-content: flex-end;
     align-items: center;
-
+    justify-content: flex-end;
     pointer-events: none;
 
     &__container {
         position: sticky;
-
         right: 0;
+        display: flex;
+        overflow: hidden;
         width: fit-content;
         height: calc(var(--rt-table-row-height) - var(--rt-table-row-border-bottom-width) - var(--rt-table-row-border-bottom-width));
-
-        display: flex;
-        justify-content: flex-end;
         align-items: center;
-        gap: 0.25rem;
+        justify-content: flex-end;
         padding: 0 0.25rem 0 1.25rem;
-
-        overflow: hidden;
-
         background: linear-gradient(
             to right,
             transparent 0%,
@@ -223,6 +206,7 @@ td.c-table__cell {
             var(--rt-table-actions-container-background-color) 20%,
             var(--rt-table-actions-container-background-color) 100%
         );
+        gap: 0.25rem;
         pointer-events: none;
     }
 

--- a/projects/ui-kit/src/styles/main.scss
+++ b/projects/ui-kit/src/styles/main.scss
@@ -4,6 +4,9 @@
 @forward 'base/base';
 @forward 'base/tokens' as tokens-*;
 
+// Material bridge — single home for global Material overrides
+@forward 'components/material-bridge';
+
 // Components
 @forward 'components/form';
 @forward 'components/button';

--- a/projects/ui-kit/src/styles/main.scss
+++ b/projects/ui-kit/src/styles/main.scss
@@ -3,6 +3,7 @@
 @forward 'base/mixin' as mixins-*;
 @forward 'base/base';
 @forward 'base/tokens' as tokens-*;
+@forward 'base/color-scheme'; // public: rt.color-scheme($name, $roles)
 
 // Material bridge — single home for global Material overrides
 @forward 'components/material-bridge';

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,5 +1,8 @@
 export default {
-    extends: ['stylelint-config-standard', './node_modules/prettier-stylelint/config.js', 'stylelint-config-idiomatic-order'],
+    // NOTE: 'prettier-stylelint/config.js' removed — it ships stylelint v14 rules deleted in v16
+    // (1700+ "Unknown rule" errors); stylelint-prettier plugin below covers prettier integration.
+    // standard-scss brings postcss-scss syntax + scss rules.
+    extends: ['stylelint-config-standard-scss', 'stylelint-config-idiomatic-order'],
     plugins: ['stylelint-scss', 'stylelint-prettier'],
     rules: {
         'at-rule-empty-line-before': [
@@ -25,6 +28,8 @@ export default {
             },
         ],
         'scss/at-rule-no-unknown': true,
+        // generateCssVar / generateCssClrVar are the repo-wide camelCase generator convention
+        'scss/at-function-pattern': null,
         'selector-pseudo-element-colon-notation': 'single',
         'selector-pseudo-element-no-unknown': [
             true,
@@ -33,6 +38,9 @@ export default {
             },
         ],
         'no-invalid-position-at-import-rule': null,
+        // The kit uses BEM (block__elem--mod) + `.--state` modifier classes and styles
+        // Material's .mdc-* internals — default kebab-case pattern rejects all of them.
+        'selector-class-pattern': null,
         'prettier/prettier': true,
         'selector-pseudo-class-no-unknown': [
             true,
@@ -41,4 +49,13 @@ export default {
             },
         ],
     },
+    overrides: [
+        {
+            // Component styles must consume tokens, not raw hex (palette lives in styles/base only)
+            files: ['projects/ui-kit/src/lib/**/*.scss'],
+            rules: {
+                'color-no-hex': true,
+            },
+        },
+    ],
 };

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -53,12 +53,14 @@ export default {
         {
             // Component styles must consume tokens, not raw hex (palette lives in styles/base only)
             files: ['projects/ui-kit/src/lib/**/*.scss'],
+            // Story/test wrapper styles are demo scaffolding, not shipped library CSS —
+            // they are exempt from the design-token discipline.
+            ignoreFiles: ['**/stories/**/*.scss', '**/strories/**/*.scss'],
             rules: {
                 'color-no-hex': true,
-                // Custom rule ported from kvaris: no hardcoded colors / magic numbers in
+                // Custom rule: no hardcoded colors / magic numbers in
                 // token-aware properties; allows var(--rt-*), --mat-*, --mdc-*, calc/min/max/clamp.
-                // Warning-level while the kit migrates remaining hardcoded values to tokens.
-                'rt-tools/no-hardcoded-design-tokens': [true, { severity: 'warning' }],
+                'rt-tools/no-hardcoded-design-tokens': true,
             },
         },
     ],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,7 +3,7 @@ export default {
     // (1700+ "Unknown rule" errors); stylelint-prettier plugin below covers prettier integration.
     // standard-scss brings postcss-scss syntax + scss rules.
     extends: ['stylelint-config-standard-scss', 'stylelint-config-idiomatic-order'],
-    plugins: ['stylelint-scss', 'stylelint-prettier'],
+    plugins: ['stylelint-scss', 'stylelint-prettier', './tools/stylelint-rules/no-hardcoded-design-tokens.cjs'],
     rules: {
         'at-rule-empty-line-before': [
             'always',
@@ -55,6 +55,10 @@ export default {
             files: ['projects/ui-kit/src/lib/**/*.scss'],
             rules: {
                 'color-no-hex': true,
+                // Custom rule ported from kvaris: no hardcoded colors / magic numbers in
+                // token-aware properties; allows var(--rt-*), --mat-*, --mdc-*, calc/min/max/clamp.
+                // Warning-level while the kit migrates remaining hardcoded values to tokens.
+                'rt-tools/no-hardcoded-design-tokens': [true, { severity: 'warning' }],
             },
         },
     ],

--- a/tools/lint-rules/index.cjs
+++ b/tools/lint-rules/index.cjs
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Кастомные ESLint-правила rt-tools.
+ * Кастомные workspace-правила для конвенций rt-tools
+ * (rtBlock/rtElem/rtMod, ModDirective, concatClasses, @rt-tools/core).
+ *
+ * Подключается в `eslint.config.cjs` как плагин `rt`:
+ *   const rt = require('./tools/eslint-rules');
+ *   { plugins: { rt }, rules: { 'rt/<name>': 'error' } }
+ */
+module.exports = {
+    rules: {
+        'require-take-until-destroyed': require('./rules/require-take-until-destroyed.cjs'),
+        'require-source-suffix-for-subjects': require('./rules/require-source-suffix-for-subjects.cjs'),
+        'require-host-bem-block': require('./rules/require-host-bem-block.cjs'),
+        'require-mod-directive-import': require('./rules/require-mod-directive-import.cjs'),
+        'require-bem-directives': require('./rules/require-bem-directives.cjs'),
+    },
+};

--- a/tools/lint-rules/rules/require-bem-directives.cjs
+++ b/tools/lint-rules/rules/require-bem-directives.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * Angular-template-правило, формализующее BEM-only-подход.
+ *
+ * Запрещает:
+ *  1. `class="..."` (статический атрибут).
+ *  2. `[class]="..."` биндинг (КРОМЕ pipe-формы `… | concatClasses`).
+ *  3. `[class.foo]="..."` boolean class binding.
+ *  4. `[ngClass]="..."`.
+ *
+ * Требует `rtBlock` / `rtElem` / `[rtMod]` из `@rt-tools/core`.
+ *
+ * Доступно в ESLint-конфигах как `rt/require-bem-directives`.
+ */
+
+/** Значение `__originalType` для биндингов вида `[class.foo]=` (BindingType.Class). */
+const BINDING_TYPE_CLASS = 2;
+
+/** Имя pipe'а — escape hatch'а. Только `… | concatClasses` допустим в `[class]=`. */
+const ALLOWED_PIPE_NAME = 'concatClasses';
+
+/**
+ * Type guard: узел `BindingPipe` с именем `concatClasses`.
+ * Распаковывает `ParenthesizedExpression` (`[class]="(['a','b'] | concatClasses)"`).
+ * Duck-typing по `constructor.name` — чтобы не тянуть @angular/compiler в lint-tsconfig.
+ */
+function isAllowedConcatPipe(ast) {
+    let current = ast;
+    while (current !== null && typeof current === 'object' && current?.constructor?.name === 'ParenthesizedExpression') {
+        current = current.expression;
+    }
+    if (current === null || typeof current !== 'object') {
+        return false;
+    }
+    if (current?.constructor?.name !== 'BindingPipe') {
+        return false;
+    }
+    return typeof current.name === 'string' && current.name === ALLOWED_PIPE_NAME;
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Forbids direct CSS-class handling in Angular templates (class=, [class]=, [class.foo]=, ' +
+                '[ngClass]=) except the [class]="… | concatClasses" escape hatch. Requires ' +
+                'rtBlock/rtElem/[rtMod] from @rt-tools/core.',
+        },
+        schema: [],
+        messages: {
+            nakedClass: 'Naked class="…" attribute is not allowed. Use rtBlock/rtElem/[rtMod] directives from @rt-tools/core.',
+            boundClass:
+                '[class]="…" binding is not allowed except the concatClasses pipe form: ' +
+                '[class]="x | concatClasses". Use rtBlock/rtElem/[rtMod] directives from @rt-tools/core.',
+            boundClassDot: '[class.NAME]="…" boolean class binding is not allowed. Use [rtMod]="{ NAME: condition }" from @rt-tools/core.',
+            ngClass:
+                '[ngClass] directive is not allowed. Use [rtMod] from @rt-tools/core ' +
+                '(string | array | object — same input shapes as ngClass).',
+        },
+    },
+    create(context) {
+        function reportNode(node, messageId) {
+            context.report({ node, messageId });
+        }
+
+        return {
+            'TextAttribute[name="class"]'(node) {
+                reportNode(node, 'nakedClass');
+            },
+            'BoundAttribute[name="ngClass"]'(node) {
+                reportNode(node, 'ngClass');
+            },
+            BoundAttribute(node) {
+                const attrName = node.name;
+                const originalType = node.__originalType;
+
+                // `[class.foo]=` — class-binding (`__originalType === 2`).
+                if (originalType === BINDING_TYPE_CLASS) {
+                    reportNode(node, 'boundClassDot');
+                    return;
+                }
+
+                // `[class]=` — Property-биндинг с name === "class". Разрешён только `… | concatClasses`.
+                if (attrName === 'class') {
+                    const rootAst = node.value?.ast;
+                    if (isAllowedConcatPipe(rootAst)) {
+                        return;
+                    }
+                    reportNode(node, 'boundClass');
+                }
+                // `ngClass` покрыт более специфичным селектором выше.
+            },
+        };
+    },
+};

--- a/tools/lint-rules/rules/require-host-bem-block.cjs
+++ b/tools/lint-rules/rules/require-host-bem-block.cjs
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * Принуждает каждый `@Component`-декоратор иметь `host: { class: BEM_BLOCK }`,
+ * где `BEM_BLOCK` — локальная const с ровно этим именем (не строковый литерал,
+ * не выражение). Унифицирует host-class pattern по всему workspace и закрывает
+ * дыру с `<ng-container rtBlock="...">` (Comment-node skip в BlockDirective —
+ * block-class не применяется на хост компонента).
+ *
+ * Доступно в ESLint-конфигах как `rt/require-host-bem-block`.
+ */
+
+const REQUIRED_IDENTIFIER = 'BEM_BLOCK';
+
+function findProperty(obj, targetKey) {
+    for (const prop of obj.properties) {
+        if (prop.type !== 'Property' || prop.computed) {
+            continue;
+        }
+        const keyName =
+            prop.key.type === 'Identifier'
+                ? prop.key.name
+                : prop.key.type === 'Literal' && typeof prop.key.value === 'string'
+                  ? prop.key.value
+                  : null;
+        if (keyName === targetKey) {
+            return prop;
+        }
+    }
+    return null;
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Every @Component decorator must declare host: { class: BEM_BLOCK } referencing a ' +
+                'local const named exactly BEM_BLOCK.',
+        },
+        schema: [],
+        messages: {
+            missingHost:
+                "@Component must declare host: { class: BEM_BLOCK }. Add `const BEM_BLOCK = '<block-name>';` " +
+                'and `host: { class: BEM_BLOCK }` to the @Component decorator.',
+            missingClassKey: "@Component.host must include 'class: BEM_BLOCK'.",
+            stringLiteralClass:
+                '@Component.host.class must reference the BEM_BLOCK const, not a string literal. ' +
+                "Define `const BEM_BLOCK = '<block-name>';` and use `class: BEM_BLOCK`.",
+            wrongIdentifier: "@Component.host.class must reference an identifier named exactly BEM_BLOCK, found '{{actual}}'.",
+            complexValue:
+                '@Component.host.class must be a direct identifier reference to BEM_BLOCK ' +
+                '(not a template literal, expression, member access, or spread).',
+        },
+    },
+    create(context) {
+        return {
+            Decorator(node) {
+                const expr = node.expression;
+                if (expr.type !== 'CallExpression' || expr.callee.type !== 'Identifier' || expr.callee.name !== 'Component') {
+                    return;
+                }
+
+                const arg = expr.arguments[0];
+                if (!arg || arg.type !== 'ObjectExpression') {
+                    context.report({ node, messageId: 'missingHost' });
+                    return;
+                }
+
+                const hostProp = findProperty(arg, 'host');
+                if (!hostProp) {
+                    context.report({ node, messageId: 'missingHost' });
+                    return;
+                }
+
+                if (hostProp.value.type !== 'ObjectExpression') {
+                    context.report({ node: hostProp, messageId: 'missingClassKey' });
+                    return;
+                }
+
+                const classProp = findProperty(hostProp.value, 'class');
+                if (!classProp) {
+                    context.report({ node: hostProp, messageId: 'missingClassKey' });
+                    return;
+                }
+
+                const classValue = classProp.value;
+                if (classValue.type === 'Literal') {
+                    context.report({ node: classProp, messageId: 'stringLiteralClass' });
+                    return;
+                }
+                if (classValue.type === 'Identifier') {
+                    if (classValue.name !== REQUIRED_IDENTIFIER) {
+                        context.report({
+                            node: classProp,
+                            messageId: 'wrongIdentifier',
+                            data: { actual: classValue.name },
+                        });
+                    }
+                    return;
+                }
+                context.report({ node: classProp, messageId: 'complexValue' });
+            },
+        };
+    },
+};

--- a/tools/lint-rules/rules/require-mod-directive-import.cjs
+++ b/tools/lint-rules/rules/require-mod-directive-import.cjs
@@ -1,0 +1,142 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * TS-сторона BEM-правил (дополняет HTML-правило require-bem-directives).
+ *
+ * Если шаблон компонента (inline или через `templateUrl`) использует директиву
+ * `rtMod` / `[rtMod]`, то массив `imports` компонента обязан содержать
+ * `ModDirective`. Иначе директива tree-shake'ается → BEM-модификаторы молча
+ * перестают применяться в проде без ошибки сборки.
+ *
+ * Документированные skip-кейсы (без false-positive):
+ *  1. `templateUrl` — не строковый литерал (динамика) → нельзя зарезолвить статически.
+ *  2. `template` — tagged template literal → skip.
+ *  3. `imports` — не plain ArrayExpression (например, ссылка на переменную) → skip.
+ *  4. `imports` содержит SpreadElement → может включать ModDirective → skip.
+ *
+ * Доступно в ESLint-конфигах как `rt/require-mod-directive-import`.
+ */
+
+const MOD_DIRECTIVE_NAME = 'ModDirective';
+const RT_TOOLS_CORE_PACKAGE = '@rt-tools/core';
+
+/** Матчит `rtMod` в позиции имени атрибута (bound `[rtMod]` и bare `rtMod`). */
+const RT_MOD_PATTERN = /(?:^|[\s[])\[?rtMod\]?(?:[\]=>"\s])/;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+
+function extractTemplateText(metadataProps, componentFilePath) {
+    for (const prop of metadataProps) {
+        if (prop.type !== 'Property' || prop.key.type !== 'Identifier') {
+            continue;
+        }
+
+        if (prop.key.name === 'template') {
+            const val = prop.value;
+            if (val.type === 'Literal' && typeof val.value === 'string') {
+                return val.value;
+            }
+            if (val.type === 'TemplateLiteral') {
+                return val.quasis.map((q) => q.value.cooked ?? '').join('');
+            }
+            return null; // tagged / non-literal — skip
+        }
+
+        if (prop.key.name === 'templateUrl') {
+            const val = prop.value;
+            if (val.type !== 'Literal' || typeof val.value !== 'string') {
+                return null; // non-literal templateUrl — skip
+            }
+            const absPath = path.resolve(path.dirname(componentFilePath), val.value);
+            try {
+                return fs.readFileSync(absPath, 'utf-8');
+            } catch {
+                return null; // IO error — skip silently
+            }
+        }
+    }
+    return null;
+}
+
+function templateUsesRtMod(templateText) {
+    return RT_MOD_PATTERN.test(templateText.replace(HTML_COMMENT_PATTERN, ''));
+}
+
+function findImportsProperty(metadataProps) {
+    for (const prop of metadataProps) {
+        if (prop.type === 'Property' && prop.key.type === 'Identifier' && prop.key.name === 'imports') {
+            return prop;
+        }
+    }
+    return null;
+}
+
+/** true когда ModDirective статически доказуемо отсутствует в imports. */
+function importsArrayLacksModDirective(importsProperty) {
+    const val = importsProperty.value;
+    if (val.type !== 'ArrayExpression') {
+        return false; // не интроспектируемо — skip
+    }
+    for (const element of val.elements) {
+        if (element === null) {
+            continue;
+        }
+        if (element.type === 'SpreadElement') {
+            return false; // spread может включать ModDirective — skip
+        }
+        if (element.type === 'Identifier' && element.name === MOD_DIRECTIVE_NAME) {
+            return false;
+        }
+    }
+    return true;
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                `Require that @Component's imports array includes ModDirective from ` +
+                `'${RT_TOOLS_CORE_PACKAGE}' whenever the component template uses the rtMod / [rtMod] directive.`,
+        },
+        schema: [],
+        messages: {
+            missingModDirective:
+                'Template uses the rtMod directive but @Component imports array does not include ' +
+                `ModDirective. Add it to imports (and import { ModDirective } from '${RT_TOOLS_CORE_PACKAGE}').`,
+        },
+    },
+    create(context) {
+        return {
+            'Decorator[expression.callee.name="Component"]'(node) {
+                const expr = node.expression;
+                if (expr.type !== 'CallExpression') {
+                    return;
+                }
+                const args = expr.arguments;
+                if (args.length === 0 || args[0].type !== 'ObjectExpression') {
+                    return;
+                }
+
+                const metadata = args[0];
+                const props = metadata.properties;
+
+                const templateText = extractTemplateText(props, context.filename);
+                if (templateText === null || !templateUsesRtMod(templateText)) {
+                    return;
+                }
+
+                const importsProperty = findImportsProperty(props);
+                if (importsProperty === null) {
+                    context.report({ node: metadata, messageId: 'missingModDirective' });
+                    return;
+                }
+                if (importsArrayLacksModDirective(importsProperty)) {
+                    context.report({ node: importsProperty, messageId: 'missingModDirective' });
+                }
+            },
+        };
+    },
+};

--- a/tools/lint-rules/rules/require-source-suffix-for-subjects.cjs
+++ b/tools/lint-rules/rules/require-source-suffix-for-subjects.cjs
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Поля класса, инициализированные `new Subject()` / `new BehaviorSubject()` /
+ * `new ReplaySubject()` / `new AsyncSubject()`, обязаны оканчиваться на суффикс
+ * `Source`. Отделяет writable-источник (мутируемый Subject) от публичного
+ * read-only Observable (`asObservable()` без суффикса).
+ *
+ * В scope:
+ *  - только class `PropertyDefinition` с инициализатором `new <Subject>(...)`.
+ *  - `#`-приватные поля обрабатываются прозрачно (имя `#refreshSource` → `refreshSource`).
+ * Вне scope: локальные переменные в методах, параметры конструктора, getter'ы.
+ *
+ * Доступно в ESLint-конфигах как `rt/require-source-suffix-for-subjects`.
+ */
+
+const SUBJECT_CONSTRUCTORS = new Set(['Subject', 'BehaviorSubject', 'ReplaySubject', 'AsyncSubject']);
+const REQUIRED_SUFFIX = 'Source';
+
+function getPropertyName(prop) {
+    const key = prop.key;
+    if (key.type === 'Identifier' || key.type === 'PrivateIdentifier') {
+        return key.name;
+    }
+    return null;
+}
+
+function isSubjectInitializer(node) {
+    if (!node || node.type !== 'NewExpression') {
+        return false;
+    }
+    const callee = node.callee;
+    return callee.type === 'Identifier' && SUBJECT_CONSTRUCTORS.has(callee.name);
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Class fields initialized with new Subject()/BehaviorSubject()/ReplaySubject()/' +
+                'AsyncSubject() must end with the `Source` suffix.',
+        },
+        schema: [],
+        messages: {
+            missingSourceSuffix:
+                "Subject-like field '{{name}}' must end with 'Source' suffix (e.g. '{{suggested}}'). " +
+                'Distinguishes the mutable Subject from its public read-only Observable.',
+        },
+    },
+    create(context) {
+        return {
+            PropertyDefinition(node) {
+                if (!isSubjectInitializer(node.value)) {
+                    return;
+                }
+                const name = getPropertyName(node);
+                if (name === null || name.endsWith(REQUIRED_SUFFIX)) {
+                    return;
+                }
+                context.report({
+                    node: node.key,
+                    messageId: 'missingSourceSuffix',
+                    data: { name, suggested: `${name}${REQUIRED_SUFFIX}` },
+                });
+            },
+        };
+    },
+};

--- a/tools/lint-rules/rules/require-take-until-destroyed.cjs
+++ b/tools/lint-rules/rules/require-take-until-destroyed.cjs
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Каждый `.subscribe()` обязан стоять после `.pipe(...)` с терминирующим
+ * оператором (`takeUntilDestroyed`/`takeUntil`/`take`/`first`/`last`/`toPromise`/
+ * `firstValueFrom`/`lastValueFrom`). Защита от утечек подписок.
+ *
+ * Доступно в ESLint-конфигах как `rt/require-take-until-destroyed`.
+ */
+
+const TERMINATING_OPERATORS = new Set([
+    'takeUntilDestroyed',
+    'takeUntil',
+    'take',
+    'first',
+    'last',
+    'toPromise',
+    'firstValueFrom',
+    'lastValueFrom',
+]);
+
+/** Поднимается вверх по цепочке `a.b().pipe(...)` и возвращает аргументы ближайшего `.pipe()`. */
+function findPipeArguments(node) {
+    let current = node;
+    while (current && current.type === 'CallExpression' && current.callee.type === 'MemberExpression') {
+        if (current.callee.property.type === 'Identifier' && current.callee.property.name === 'pipe') {
+            return current.arguments;
+        }
+        current = current.callee.object;
+    }
+    return null;
+}
+
+function hasTerminatingOperator(args) {
+    return args.some(
+        (arg) => arg.type === 'CallExpression' && arg.callee.type === 'Identifier' && TERMINATING_OPERATORS.has(arg.callee.name)
+    );
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Require every .subscribe() to be terminated via takeUntilDestroyed() or another ' +
+                'terminating operator (takeUntil/take/first/firstValueFrom/...).',
+        },
+        schema: [],
+        messages: {
+            missing:
+                'Subscription must be terminated via takeUntilDestroyed() or another terminating ' +
+                'operator (takeUntil/take/first/firstValueFrom/...).',
+        },
+    },
+    create(context) {
+        return {
+            'CallExpression[callee.type="MemberExpression"][callee.property.name="subscribe"]'(node) {
+                const pipeArgs = findPipeArguments(node.callee.object);
+                if (!pipeArgs || !hasTerminatingOperator(pipeArgs)) {
+                    context.report({ node, messageId: 'missing' });
+                }
+            },
+        };
+    },
+};

--- a/tools/stylelint-rules/no-hardcoded-design-tokens.cjs
+++ b/tools/stylelint-rules/no-hardcoded-design-tokens.cjs
@@ -1,0 +1,682 @@
+'use strict';
+
+const stylelint = require('stylelint');
+const valueParser = require('module').createRequire(require.resolve('stylelint'))('postcss-value-parser');
+
+/**
+ * Запрещает хардкод дизайн-значений в component-SCSS rt-tools.
+ *
+ * Разрешённые var-префиксы: `--rt-*` (проектные токены), `--mat-*` / `--mdc-*`
+ * (Angular Material bridge). Любой другой `var(--x)` — нарушение.
+ *
+ * По группам свойства запрещает: хардкод цветов (hex/named/rgb/hsl), magic numbers
+ * в padding/margin/gap/radius/font-size/border-width/..., SCSS-функции цвета и
+ * `$vars`/`#{}`-интерполяцию. Разрешает calc/min/max/clamp, color-mix/color и
+ * modern-color-функции `from var()`, `0`, universal-ключевые слова.
+ *
+ */
+
+const RULE_NAME = 'rt-tools/no-hardcoded-design-tokens';
+
+const messages = stylelint.utils.ruleMessages(RULE_NAME, {
+    hardcodedColor: (value) => `"${value}" — use var(--rt-*) (or --mat-*/--mdc-*). Hardcoded colors break theming.`,
+    hardcodedNumeric: (value, prop) => `"${value}" in ${prop} — use var(--rt-*). No magic numbers.`,
+    hardcodedNumber: (value, prop) => `"${value}" in ${prop} — use var(--rt-*) instead of a unitless literal.`,
+    forbiddenVarPrefix: (name) => `var(${name}) — only --rt-*, --mat-* and --mdc-* prefixes are allowed.`,
+    scssExpression: (value) => `"${value}" — SCSS expressions do not respect CSS theming. Use var(--rt-*).`,
+    compositeRequired: (prop) => `${prop} must use a single var(--rt-*) composite token (or "none").`,
+});
+
+/** Префиксы CSS-переменных, признаваемые дизайн-токенами. */
+const ALLOWED_VAR_PREFIX = /^--(rt|mat|mdc)-/;
+
+const UNIVERSAL_KEYWORDS = new Set([
+    'auto',
+    'none',
+    'inherit',
+    'initial',
+    'unset',
+    'revert',
+    'revert-layer',
+    'transparent',
+    'currentcolor',
+]);
+
+const BORDER_STYLE_KEYWORDS = new Set(['solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset', 'none', 'hidden']);
+
+const FONT_STYLE_KEYWORDS = new Set(['italic', 'normal', 'oblique']);
+
+const TIMING_FUNCTION_KEYWORDS = new Set(['linear', 'ease', 'ease-in', 'ease-out', 'ease-in-out', 'step-start', 'step-end']);
+
+const TIMING_FUNCTION_FUNCS = new Set(['cubic-bezier', 'steps']);
+
+const ANIMATION_DIRECTION_KEYWORDS = new Set([
+    'normal',
+    'reverse',
+    'alternate',
+    'alternate-reverse',
+    'forwards',
+    'backwards',
+    'both',
+    'running',
+    'paused',
+    'infinite',
+]);
+
+const SAFE_COLOR_FUNCS = new Set(['color-mix', 'color']);
+
+const NAMED_CSS_COLORS = new Set([
+    'aliceblue',
+    'antiquewhite',
+    'aqua',
+    'aquamarine',
+    'azure',
+    'beige',
+    'bisque',
+    'black',
+    'blanchedalmond',
+    'blue',
+    'blueviolet',
+    'brown',
+    'burlywood',
+    'cadetblue',
+    'chartreuse',
+    'chocolate',
+    'coral',
+    'cornflowerblue',
+    'cornsilk',
+    'crimson',
+    'cyan',
+    'darkblue',
+    'darkcyan',
+    'darkgoldenrod',
+    'darkgray',
+    'darkgreen',
+    'darkgrey',
+    'darkkhaki',
+    'darkmagenta',
+    'darkolivegreen',
+    'darkorange',
+    'darkorchid',
+    'darkred',
+    'darksalmon',
+    'darkseagreen',
+    'darkslateblue',
+    'darkslategray',
+    'darkslategrey',
+    'darkturquoise',
+    'darkviolet',
+    'deeppink',
+    'deepskyblue',
+    'dimgray',
+    'dimgrey',
+    'dodgerblue',
+    'firebrick',
+    'floralwhite',
+    'forestgreen',
+    'fuchsia',
+    'gainsboro',
+    'ghostwhite',
+    'gold',
+    'goldenrod',
+    'gray',
+    'green',
+    'greenyellow',
+    'grey',
+    'honeydew',
+    'hotpink',
+    'indianred',
+    'indigo',
+    'ivory',
+    'khaki',
+    'lavender',
+    'lavenderblush',
+    'lawngreen',
+    'lemonchiffon',
+    'lightblue',
+    'lightcoral',
+    'lightcyan',
+    'lightgoldenrodyellow',
+    'lightgray',
+    'lightgreen',
+    'lightgrey',
+    'lightpink',
+    'lightsalmon',
+    'lightseagreen',
+    'lightskyblue',
+    'lightslategray',
+    'lightslategrey',
+    'lightsteelblue',
+    'lightyellow',
+    'lime',
+    'limegreen',
+    'linen',
+    'magenta',
+    'maroon',
+    'mediumaquamarine',
+    'mediumblue',
+    'mediumorchid',
+    'mediumpurple',
+    'mediumseagreen',
+    'mediumslateblue',
+    'mediumspringgreen',
+    'mediumturquoise',
+    'mediumvioletred',
+    'midnightblue',
+    'mintcream',
+    'mistyrose',
+    'moccasin',
+    'navajowhite',
+    'navy',
+    'oldlace',
+    'olive',
+    'olivedrab',
+    'orange',
+    'orangered',
+    'orchid',
+    'palegoldenrod',
+    'palegreen',
+    'paleturquoise',
+    'palevioletred',
+    'papayawhip',
+    'peachpuff',
+    'peru',
+    'pink',
+    'plum',
+    'powderblue',
+    'purple',
+    'rebeccapurple',
+    'red',
+    'rosybrown',
+    'royalblue',
+    'saddlebrown',
+    'salmon',
+    'sandybrown',
+    'seagreen',
+    'seashell',
+    'sienna',
+    'silver',
+    'skyblue',
+    'slateblue',
+    'slategray',
+    'slategrey',
+    'snow',
+    'springgreen',
+    'steelblue',
+    'tan',
+    'teal',
+    'thistle',
+    'tomato',
+    'turquoise',
+    'violet',
+    'wheat',
+    'white',
+    'whitesmoke',
+    'yellow',
+    'yellowgreen',
+]);
+
+const HEX_PATTERN = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const NUMERIC_PATTERN =
+    /^-?(\d+\.?\d*|\.\d+)(px|em|rem|vh|vw|vmin|vmax|svh|svw|dvh|dvw|lvh|lvw|%|s|ms|deg|rad|turn|pt|pc|cm|mm|in|fr|ch|ex|q|cap|ic|lh|rlh|cqi|cqb|cqmin|cqmax|cqw|cqh)?$/i;
+const ZERO_PATTERN = /^-?0(\.0+)?(px|em|rem|ms|s|%|vh|vw|deg)?$/i;
+const SCSS_VAR_PATTERN = /^\$[\w-]/;
+const SCSS_INTERP_PATTERN = /#\{/;
+const SCSS_COLOR_FUNCS = new Set([
+    'darken',
+    'lighten',
+    'saturate',
+    'desaturate',
+    'adjust-hue',
+    'complement',
+    'invert',
+    'mix',
+    'transparentize',
+    'opacify',
+    'fade-in',
+    'fade-out',
+]);
+
+const ARITHMETIC_OPERATORS = new Set(['+', '-', '*', '/']);
+
+const PROPERTY_GROUPS = {
+    inspectNumeric: new Set([
+        'padding',
+        'padding-top',
+        'padding-right',
+        'padding-bottom',
+        'padding-left',
+        'margin',
+        'margin-top',
+        'margin-right',
+        'margin-bottom',
+        'margin-left',
+        'gap',
+        'row-gap',
+        'column-gap',
+        'border-radius',
+        'border-top-left-radius',
+        'border-top-right-radius',
+        'border-bottom-left-radius',
+        'border-bottom-right-radius',
+        'font-size',
+        'border-width',
+        'border-top-width',
+        'border-right-width',
+        'border-bottom-width',
+        'border-left-width',
+        'letter-spacing',
+    ]),
+    inspectColor: new Set([
+        'color',
+        'background-color',
+        'background-image',
+        'fill',
+        'stroke',
+        'outline-color',
+        'caret-color',
+        'accent-color',
+        'text-decoration-color',
+        'column-rule-color',
+        'border-color',
+        'border-top-color',
+        'border-right-color',
+        'border-bottom-color',
+        'border-left-color',
+    ]),
+    fontWeight: new Set(['font-weight']),
+    lineHeight: new Set(['line-height']),
+    fontStyle: new Set(['font-style']),
+    borderStyle: new Set(['border-style', 'border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style']),
+    composite: new Set(['box-shadow', 'text-shadow']),
+    borderShorthand: new Set(['border', 'border-top', 'border-right', 'border-bottom', 'border-left']),
+    transitionList: new Set(['transition']),
+    transitionTime: new Set(['transition-duration', 'transition-delay']),
+    transitionTiming: new Set(['transition-timing-function']),
+    animationList: new Set(['animation']),
+    animationTime: new Set(['animation-duration', 'animation-delay']),
+    animationTiming: new Set(['animation-timing-function']),
+    animationIterationCount: new Set(['animation-iteration-count']),
+    animationEnum: new Set(['animation-direction', 'animation-fill-mode', 'animation-play-state']),
+};
+
+function classifyProperty(prop) {
+    for (const [group, set] of Object.entries(PROPERTY_GROUPS)) {
+        if (set.has(prop)) return group;
+    }
+    return null;
+}
+
+function isAllowedVar(node) {
+    if (node.type !== 'function' || node.value !== 'var') return false;
+    const first = node.nodes.find((n) => n.type === 'word');
+    if (!first) return false;
+    return ALLOWED_VAR_PREFIX.test(first.value);
+}
+
+function isForbiddenVarPrefix(node) {
+    if (node.type !== 'function' || node.value !== 'var') return false;
+    const first = node.nodes.find((n) => n.type === 'word');
+    if (!first) return false;
+    return !ALLOWED_VAR_PREFIX.test(first.value);
+}
+
+function isAllowedMathFunc(node) {
+    if (node.type !== 'function') return false;
+    return ['calc', 'min', 'max', 'clamp'].includes(node.value);
+}
+
+function nextSignificantSibling(nodes, idx) {
+    for (let j = idx + 1; j < nodes.length; j++) {
+        const n = nodes[j];
+        if (n.type !== 'space' && n.type !== 'div') return n;
+    }
+    return null;
+}
+
+function hasFromVarSource(node) {
+    return node.nodes.some((n, i, arr) => {
+        if (n.type !== 'word' || n.value !== 'from') return false;
+        const next = nextSignificantSibling(arr, i);
+        return next !== null && isAllowedVar(next);
+    });
+}
+
+function isSafeColorFunc(node) {
+    if (node.type !== 'function') return false;
+    if (!SAFE_COLOR_FUNCS.has(node.value)) return false;
+    if (node.value === 'color-mix') {
+        return node.nodes.some((n) => isAllowedVar(n));
+    }
+    return hasFromVarSource(node);
+}
+
+function isModernColorWithVarSource(node) {
+    if (node.type !== 'function') return false;
+    if (!['rgb', 'rgba', 'hsl', 'hsla', 'hwb', 'lab', 'lch', 'oklab', 'oklch'].includes(node.value)) {
+        return false;
+    }
+    return hasFromVarSource(node);
+}
+
+function isZeroWord(word) {
+    return ZERO_PATTERN.test(word) && /^-?0/.test(word);
+}
+
+function isUniversalKeyword(word) {
+    return UNIVERSAL_KEYWORDS.has(word.toLowerCase());
+}
+
+function isHexColor(word) {
+    return HEX_PATTERN.test(word);
+}
+
+function isNamedColor(word) {
+    return NAMED_CSS_COLORS.has(word.toLowerCase());
+}
+
+function isNumericLiteral(word) {
+    return NUMERIC_PATTERN.test(word);
+}
+
+function isUnitlessNumber(word) {
+    return /^-?\d+\.?\d*$|^-?\.\d+$/.test(word);
+}
+
+function isScssExpression(raw) {
+    return SCSS_VAR_PATTERN.test(raw) || SCSS_INTERP_PATTERN.test(raw);
+}
+
+function isScssColorFunc(node) {
+    return node.type === 'function' && SCSS_COLOR_FUNCS.has(node.value);
+}
+
+function walkAndReport(nodes, propName, group, report, inMathFunc) {
+    for (const node of nodes) {
+        if (node.type === 'space' || node.type === 'div') continue;
+
+        if (node.type === 'function') {
+            if (isAllowedVar(node)) continue;
+            if (isForbiddenVarPrefix(node)) {
+                const inner = node.nodes.find((n) => n.type === 'word');
+                report({
+                    msg: messages.forbiddenVarPrefix(inner ? inner.value : '?'),
+                    word: valueParser.stringify(node),
+                });
+                continue;
+            }
+            if (isAllowedMathFunc(node)) {
+                walkAndReport(node.nodes, propName, group, report, true);
+                continue;
+            }
+            if (isSafeColorFunc(node) || isModernColorWithVarSource(node)) {
+                continue;
+            }
+            if (isScssColorFunc(node)) {
+                report({ msg: messages.scssExpression(valueParser.stringify(node)), word: valueParser.stringify(node) });
+                continue;
+            }
+            if (['rgb', 'rgba', 'hsl', 'hsla', 'hwb'].includes(node.value)) {
+                report({ msg: messages.hardcodedColor(valueParser.stringify(node)), word: valueParser.stringify(node) });
+                continue;
+            }
+            if (
+                ['linear-gradient', 'radial-gradient', 'conic-gradient', 'repeating-linear-gradient', 'repeating-radial-gradient'].includes(
+                    node.value
+                )
+            ) {
+                walkAndReport(node.nodes, propName, 'inspectColor', report, inMathFunc);
+                continue;
+            }
+            walkAndReport(node.nodes, propName, group, report, inMathFunc);
+            continue;
+        }
+
+        if (node.type !== 'word') continue;
+        const word = node.value;
+
+        if (inMathFunc) {
+            if (ARITHMETIC_OPERATORS.has(word)) continue;
+            if (isUnitlessNumber(word)) continue;
+            if (isNumericLiteral(word) && !isZeroWord(word)) {
+                report({ msg: messages.hardcodedNumeric(word, propName), word });
+                continue;
+            }
+            if (isHexColor(word) || isNamedColor(word)) {
+                report({ msg: messages.hardcodedColor(word), word });
+                continue;
+            }
+            if (isScssExpression(word)) {
+                report({ msg: messages.scssExpression(word), word });
+                continue;
+            }
+            continue;
+        }
+
+        if (isScssExpression(word)) {
+            report({ msg: messages.scssExpression(word), word });
+            continue;
+        }
+
+        if (isZeroWord(word)) continue;
+        if (isUniversalKeyword(word)) continue;
+
+        if (group === 'inspectColor' || group === 'colorSubcontext') {
+            if (isHexColor(word)) {
+                report({ msg: messages.hardcodedColor(word), word });
+                continue;
+            }
+            if (isNamedColor(word)) {
+                report({ msg: messages.hardcodedColor(word), word });
+                continue;
+            }
+            if (isNumericLiteral(word) || isUnitlessNumber(word)) {
+                report({ msg: messages.hardcodedNumeric(word, propName), word });
+                continue;
+            }
+            report({ msg: messages.hardcodedColor(word), word });
+            continue;
+        }
+
+        if (group === 'inspectNumeric') {
+            if (isNumericLiteral(word)) {
+                report({ msg: messages.hardcodedNumeric(word, propName), word });
+                continue;
+            }
+            if (isUnitlessNumber(word)) {
+                report({ msg: messages.hardcodedNumber(word, propName), word });
+                continue;
+            }
+            if (isHexColor(word) || isNamedColor(word)) {
+                report({ msg: messages.hardcodedColor(word), word });
+                continue;
+            }
+            report({ msg: messages.hardcodedNumeric(word, propName), word });
+            continue;
+        }
+
+        if (group === 'fontWeight' || group === 'lineHeight') {
+            if (isUnitlessNumber(word) || isNumericLiteral(word)) {
+                report({ msg: messages.hardcodedNumber(word, propName), word });
+                continue;
+            }
+            report({ msg: messages.hardcodedNumber(word, propName), word });
+            continue;
+        }
+
+        if (group === 'fontStyle') {
+            if (FONT_STYLE_KEYWORDS.has(word.toLowerCase())) continue;
+            report({ msg: messages.hardcodedNumeric(word, propName), word });
+            continue;
+        }
+
+        if (group === 'borderStyle') {
+            if (BORDER_STYLE_KEYWORDS.has(word.toLowerCase())) continue;
+            report({ msg: messages.hardcodedNumeric(word, propName), word });
+            continue;
+        }
+
+        if (group === 'transitionTiming' || group === 'animationTiming') {
+            if (TIMING_FUNCTION_KEYWORDS.has(word.toLowerCase())) continue;
+            report({ msg: messages.hardcodedNumeric(word, propName), word });
+            continue;
+        }
+
+        if (group === 'transitionTime' || group === 'animationTime') {
+            if (isNumericLiteral(word)) {
+                report({ msg: messages.hardcodedNumeric(word, propName), word });
+                continue;
+            }
+            continue;
+        }
+
+        if (group === 'animationIterationCount') {
+            if (word.toLowerCase() === 'infinite') continue;
+            if (/^\d+$/.test(word)) continue;
+            report({ msg: messages.hardcodedNumeric(word, propName), word });
+            continue;
+        }
+
+        if (group === 'animationEnum') {
+            if (ANIMATION_DIRECTION_KEYWORDS.has(word.toLowerCase())) continue;
+            continue;
+        }
+
+        if (group === 'borderShorthandContext') {
+            if (BORDER_STYLE_KEYWORDS.has(word.toLowerCase())) continue;
+            if (isNumericLiteral(word)) {
+                report({ msg: messages.hardcodedNumeric(word, propName), word });
+                continue;
+            }
+            if (isHexColor(word) || isNamedColor(word)) {
+                report({ msg: messages.hardcodedColor(word), word });
+                continue;
+            }
+            if (isUnitlessNumber(word)) {
+                report({ msg: messages.hardcodedNumber(word, propName), word });
+                continue;
+            }
+        }
+    }
+}
+
+function checkComposite(parsed, propName, report) {
+    const sigNodes = parsed.nodes.filter((n) => n.type !== 'space' && n.type !== 'div');
+    if (sigNodes.length === 1) {
+        const only = sigNodes[0];
+        if (only.type === 'word' && (isUniversalKeyword(only.value) || isZeroWord(only.value))) {
+            return;
+        }
+        if (only.type === 'function' && isAllowedVar(only)) return;
+    }
+    const allAllowed = sigNodes.every((n) => {
+        if (n.type === 'word') return isUniversalKeyword(n.value) || isZeroWord(n.value);
+        if (n.type === 'function') return isAllowedVar(n) || isAllowedMathFunc(n);
+        return false;
+    });
+    if (allAllowed) return;
+    report({ msg: messages.compositeRequired(propName), word: valueParser.stringify(parsed) });
+}
+
+function checkTransitionOrAnimationList(parsed, propName, report) {
+    const items = [];
+    let current = [];
+    for (const node of parsed.nodes) {
+        if (node.type === 'div' && node.value === ',') {
+            items.push(current);
+            current = [];
+            continue;
+        }
+        current.push(node);
+    }
+    if (current.length) items.push(current);
+
+    for (const item of items) {
+        for (const node of item) {
+            if (node.type === 'space' || node.type === 'div') continue;
+            if (node.type === 'word') {
+                const w = node.value;
+                if (isUniversalKeyword(w) || isZeroWord(w)) continue;
+                if (TIMING_FUNCTION_KEYWORDS.has(w.toLowerCase())) continue;
+                if (ANIMATION_DIRECTION_KEYWORDS.has(w.toLowerCase())) continue;
+                if (/^\d+$/.test(w)) continue;
+                if (isNumericLiteral(w)) {
+                    report({ msg: messages.hardcodedNumeric(w, propName), word: w });
+                    continue;
+                }
+                if (isScssExpression(w)) {
+                    report({ msg: messages.scssExpression(w), word: w });
+                    continue;
+                }
+                continue;
+            }
+            if (node.type === 'function') {
+                if (isAllowedVar(node)) continue;
+                if (isForbiddenVarPrefix(node)) {
+                    const inner = node.nodes.find((n) => n.type === 'word');
+                    report({
+                        msg: messages.forbiddenVarPrefix(inner ? inner.value : '?'),
+                        word: valueParser.stringify(node),
+                    });
+                    continue;
+                }
+                if (TIMING_FUNCTION_FUNCS.has(node.value)) continue;
+                if (isAllowedMathFunc(node)) {
+                    walkAndReport(node.nodes, propName, 'inspectNumeric', report);
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+const ruleFunction = (primary, _options, _context) => {
+    return (root, result) => {
+        const validOptions = stylelint.utils.validateOptions(result, RULE_NAME, {
+            actual: primary,
+            possible: [true, false],
+        });
+        if (!validOptions || !primary) return;
+
+        root.walkDecls((decl) => {
+            const propName = decl.prop.toLowerCase();
+            if (propName.startsWith('--')) return;
+            if (propName.startsWith('$')) return;
+
+            const group = classifyProperty(propName);
+            if (!group) return;
+
+            const parsed = valueParser(decl.value);
+
+            const report = ({ msg, word }) => {
+                stylelint.utils.report({
+                    message: msg,
+                    node: decl,
+                    word: word || decl.value,
+                    result,
+                    ruleName: RULE_NAME,
+                });
+            };
+
+            if (group === 'composite') {
+                checkComposite(parsed, propName, report);
+                return;
+            }
+            if (group === 'transitionList' || group === 'animationList') {
+                checkTransitionOrAnimationList(parsed, propName, report);
+                return;
+            }
+            if (group === 'borderShorthand') {
+                walkAndReport(parsed.nodes, propName, 'borderShorthandContext', report);
+                return;
+            }
+            walkAndReport(parsed.nodes, propName, group, report);
+        });
+    };
+};
+
+ruleFunction.ruleName = RULE_NAME;
+ruleFunction.messages = messages;
+ruleFunction.meta = { fixable: false };
+
+module.exports = stylelint.createPlugin(RULE_NAME, ruleFunction);

--- a/tools/stylelint-rules/no-hardcoded-design-tokens.cjs
+++ b/tools/stylelint-rules/no-hardcoded-design-tokens.cjs
@@ -260,12 +260,9 @@ const PROPERTY_GROUPS = {
         'border-bottom-left-radius',
         'border-bottom-right-radius',
         'font-size',
-        'border-width',
-        'border-top-width',
-        'border-right-width',
-        'border-bottom-width',
-        'border-left-width',
-        'letter-spacing',
+        // NOTE: border-width / letter-spacing / line-height intentionally NOT enforced —
+        // rt-tools has no token scale for hairline border widths, letter-spacing or
+        // line-height ratios, so literals there are legitimate (not magic design tokens).
     ]),
     inspectColor: new Set([
         'color',
@@ -285,19 +282,25 @@ const PROPERTY_GROUPS = {
         'border-left-color',
     ]),
     fontWeight: new Set(['font-weight']),
-    lineHeight: new Set(['line-height']),
+    lineHeight: new Set(),
     fontStyle: new Set(['font-style']),
     borderStyle: new Set(['border-style', 'border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style']),
     composite: new Set(['box-shadow', 'text-shadow']),
-    borderShorthand: new Set(['border', 'border-top', 'border-right', 'border-bottom', 'border-left']),
-    transitionList: new Set(['transition']),
-    transitionTime: new Set(['transition-duration', 'transition-delay']),
-    transitionTiming: new Set(['transition-timing-function']),
-    animationList: new Set(['animation']),
-    animationTime: new Set(['animation-duration', 'animation-delay']),
-    animationTiming: new Set(['animation-timing-function']),
-    animationIterationCount: new Set(['animation-iteration-count']),
-    animationEnum: new Set(['animation-direction', 'animation-fill-mode', 'animation-play-state']),
+    // border shorthand widths are not enforced (no rt-tools border-width token scale);
+    // hardcoded border COLORS are still caught by the separate color-no-hex rule.
+    borderShorthand: new Set(),
+    // Motion (transition/animation) is NOT enforced: rt-tools' only motion tokens
+    // (--rt-transition-*) bundle a timing function, so they can't be substituted into
+    // shorthands that carry custom easing (linear/ease/cubic-bezier), and there is no
+    // bare-duration token scale. Bare durations/delays there are therefore legitimate.
+    transitionList: new Set(),
+    transitionTime: new Set(),
+    transitionTiming: new Set(),
+    animationList: new Set(),
+    animationTime: new Set(),
+    animationTiming: new Set(),
+    animationIterationCount: new Set(),
+    animationEnum: new Set(),
 };
 
 function classifyProperty(prop) {


### PR DESCRIPTION
## Summary

Two coordinated tracks on this branch:

### 1. Custom color schemes (brand palette)
Lets a consuming app supply its own brand palette so the whole `--rt-*` accent layer
recolors (light + dark + auto, runtime-switchable) without touching kit internals and
without duplicating the semantic tier.

- **Accent indirection:** semantic accent tokens derive from `--rt-color-{role}-{0..100}`
  ramps (primary/info/success/warning/danger/brand) instead of hardcoded hex. Tones that
  mapped to Material carry the `--mat-sys-*` fallback **inside the tone**, so the default
  render honors Material and a scheme override wins over it.
- **Δ0:** own-palette render is byte-for-byte identical to before (regression-tested).
- **Sass API:** `rt.color-scheme($name, $roles)` emits a scoped `:root[data-rt-scheme]`
  block (raw role rows only) with input validation.
- **Runtime:** `RtThemeService.setColorScheme(name|null)` + `colorScheme` signal +
  `registerColorScheme(name, ramp)` JS twin (validated at parity with the mixin);
  persisted to `rt-color-scheme`, `data-rt-scheme` on `<html>`, SSR-safe, orthogonal to light/dark.
- **Docs:** Storybook `Foundation/Theming/Custom color schemes`, `TOKENS.md`.

### 2. Lint-rule additions + design-token hygiene
- Custom ESLint + stylelint rules; `no-hardcoded-design-tokens` enforced at error.
- Replaced hardcoded SCSS values with design tokens; removed the legacy `--clr-*` layer.
- Fixed leaking RxJS subscriptions; added missing `ModDirective` imports for `rtMod`.

## Verification
- color-scheme specs: **17/17** (Δ0 regression, Material hybrid, dark tone-selection,
  mixin + JS validation parity).
- stylelint clean, eslint 0 errors, build ok.

## Notes
- A Δ0 contract test against a consumer's own `--clr-*` ramp (light + dark) lives on the
  consumer side, since the kit ships no consumer palette.
