### PR TITLE
chore: add Claude Code skills for PR/CHANGELOG and project board

### DIFF
--- a/.claude/skills/rt-tools-board/REFERENCE.md
+++ b/.claude/skills/rt-tools-board/REFERENCE.md
@@ -1,0 +1,58 @@
+# Reference — board details
+
+## Status values
+
+The board's Status field, in flow order:
+
+```
+🆕 New → 📋 Backlog → 🔖 Ready → 🏗 In progress → 👀 In review → ✅ Done → Deployed
+```
+
+`board.sh status <num> "<text>"` matches case-insensitively on a substring, so:
+
+| intent      | command argument |
+| ----------- | ---------------- |
+| start work  | `"progress"`     |
+| PR opened   | `"review"`       |
+| merged/done | `"done"`         |
+| shipped     | `"deployed"`     |
+
+Ambiguous or unmatched text fails loudly rather than guessing.
+
+## Branch slug rules
+
+- Lowercase, words joined by `-`, ASCII only.
+- Drop articles/filler; keep it to ~3–5 meaningful words from the issue title.
+- Example: issue #14 "Store shouldn't return undefined values" →
+  `fix/14-store-undefined-values`.
+
+Pick the `type` from the nature of the work, matching the eventual commit type:
+`feat`, `fix`, `refactor`, `docs`, `chore`, `style`, `test`, `perf`.
+
+## Creating a task from a change already in progress
+
+If a branch/PR exists without a task:
+
+1. Create the issue describing the change:
+   `command gh issue create --title "<title>" --body "<what & why>"`.
+2. `scripts/board.sh add <issue-number>`.
+3. Add `Closes #<issue-number>` to the PR body (rt-tools-ship-pr handles the body).
+4. Optionally rename the branch to `type/<num>-<slug>` if it was generic:
+   `command git branch -m <new-name>` (only before it has an open PR; renaming a
+   pushed branch with an open PR breaks the PR — open a fresh one instead).
+
+## Linking PR ↔ issue
+
+- `Closes #<num>` / `Fixes #<num>` in the PR body auto-closes the issue on merge
+  and moves the board item to Done via the board's built-in automation (if
+  configured). Still set `"review"` explicitly when the PR opens.
+- The board's **Linked pull requests** field populates automatically once the PR
+  references the issue.
+
+## Notes
+
+- `board.sh` matches the board by title (`Rt-tools`) under the repo's own owner,
+  resolved from the git remote — so it works in any clone without editing IDs.
+  Override the title via `RT_BOARD_TITLE=... scripts/board.sh ...` if needed.
+- If a bare `gh`/`git` errors with an account-selection message, prefix with
+  `command`.

--- a/.claude/skills/rt-tools-board/SKILL.md
+++ b/.claude/skills/rt-tools-board/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: rt-tools-board
+description: Manage the project board for this repo — every PR must map to a board task (issue). Create a tracking issue for new work or pick an existing one, branch off it as type/<num>-<slug>, add it to the board, and move its Status (In progress when work starts, In review when the PR opens). Use when asked to start a task, pick up a board item, create an issue for a change, name a feature branch by task number, or update a task's status on the board. For the push/PR/CHANGELOG step, hand off to the rt-tools-ship-pr skill.
+---
+
+# Project board workflow
+
+Every PR is tied to exactly one board task (a GitHub issue on the board). Start
+from a task, branch off it, and keep its Status in sync.
+
+## Golden rule
+
+No PR without a task. Either pick an existing board item or create an issue
+first, then branch from it.
+
+## Branch naming
+
+`type/<issue-number>-<slug>` — conventional type (`feat` / `fix` / `refactor` /
+`docs` / `chore` / `style`) + issue number + short kebab slug from the title.
+
+```
+feat/88-add-select-button
+fix/14-store-undefined-values
+```
+
+## Helper
+
+All board operations go through `scripts/board.sh` (resolves owner, board number
+and field IDs at runtime — nothing account-specific is hardcoded):
+
+```bash
+scripts/board.sh info                    # owner, board #, status options
+scripts/board.sh list                    # board items: status | type#num | title
+scripts/board.sh add <num>               # add issue/PR #num to the board
+scripts/board.sh status <num> "review"   # set Status (substring match)
+```
+
+## Workflow
+
+1. **Get or create the task.**
+    - Existing: `scripts/board.sh list` → pick the item, note its issue number.
+    - New: `command gh issue create --title "<title>" --body "<context>"`, then
+      `scripts/board.sh add <new-issue-number>`.
+
+2. **Branch off `main`** with the naming above:
+
+    ```bash
+    command git switch main && command git pull
+    command git switch -c feat/<num>-<slug>
+    ```
+
+3. **Mark In progress:** `scripts/board.sh status <num> "progress"`.
+
+4. **Do the work and commit.** Reference the task in commits where natural.
+
+5. **Open the PR** — hand off to the **rt-tools-ship-pr** skill (push + PR body +
+   CHANGELOG). Add `Closes #<num>` to the PR body so the issue auto-closes on
+   merge.
+
+6. **Mark In review:** `scripts/board.sh status <num> "review"`.
+
+See [REFERENCE.md](REFERENCE.md) for status names, slug rules, and edge cases.

--- a/.claude/skills/rt-tools-board/scripts/board.sh
+++ b/.claude/skills/rt-tools-board/scripts/board.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Project-board helper. Resolves the board owner, number and field IDs at
+# runtime (nothing account-specific is hardcoded) and drives item status.
+#
+# The board is matched by title (default below) under the repo's own owner,
+# so the same script works for any clone without editing IDs.
+#
+# Usage:
+#   board.sh info                       # owner, project number/id, status options
+#   board.sh list                       # board items: status | type#num | title
+#   board.sh add <num>                  # add issue/PR #num to the board
+#   board.sh status <num> "<status>"    # set Status (substring match, e.g. "review")
+#
+# Some setups route bare git/gh through an account-selection shim that errors;
+# this script always calls them via `command` to bypass it.
+
+set -euo pipefail
+
+BOARD_TITLE="${RT_BOARD_TITLE:-Rt-tools}"
+export BOARD_TITLE
+GH="command gh"
+PY="command python3"
+
+owner() { $GH repo view --json owner -q .owner.login; }
+
+# Resolve board number + node id by exact title under the owner.
+resolve_project() {
+    local o; o="$(owner)"
+    $GH project list --owner "$o" --format json | $PY -c "
+import json,sys
+d=json.load(sys.stdin)
+m=[p for p in d['projects'] if p['title']==__import__('os').environ['BOARD_TITLE']]
+if not m:
+    sys.exit('board \"%s\" not found for owner' % __import__('os').environ['BOARD_TITLE'])
+print(m[0]['number'], m[0]['id'])
+"
+}
+
+status_field_json() {
+    local num="$1" o; o="$(owner)"
+    $GH project field-list "$num" --owner "$o" --format json
+}
+
+cmd_info() {
+    local o num pid; o="$(owner)"
+    read -r num pid < <(resolve_project)
+    echo "owner:   $o"
+    echo "board:   $BOARD_TITLE (#$num)"
+    echo "id:      $pid"
+    echo "status options:"
+    status_field_json "$num" | $PY -c "
+import json,sys
+d=json.load(sys.stdin)
+for f in d['fields']:
+    if f['name']=='Status':
+        for op in f['options']: print('  -', op['name'])
+"
+}
+
+cmd_list() {
+    local o num pid; o="$(owner)"
+    read -r num pid < <(resolve_project)
+    $GH project item-list "$num" --owner "$o" --format json | $PY -c "
+import json,sys
+d=json.load(sys.stdin)
+for it in d['items']:
+    c=it.get('content',{}) or {}
+    print('%-14s %s#%-5s %s' % (it.get('status','-'), c.get('type','?'), c.get('number','?'), it.get('title','')[:60]))
+"
+}
+
+cmd_add() {
+    local target="$1" o url; o="$(owner)"
+    url="$($GH issue view "$target" --json url -q .url 2>/dev/null || $GH pr view "$target" --json url -q .url)"
+    local num _pid; read -r num _pid < <(resolve_project)
+    $GH project item-add "$num" --owner "$o" --url "$url"
+    echo "added $url to $BOARD_TITLE"
+}
+
+cmd_status() {
+    local target="$1" want="$2" o num pid; o="$(owner)"
+    read -r num pid < <(resolve_project)
+
+    local fieldId optId
+    read -r fieldId optId < <(status_field_json "$num" | WANT="$want" $PY -c "
+import json,sys,os
+d=json.load(sys.stdin); want=os.environ['WANT'].lower()
+for f in d['fields']:
+    if f['name']=='Status':
+        opts=[o for o in f['options'] if want in o['name'].lower()]
+        if not opts: sys.exit('no Status option matching \"%s\"' % want)
+        if len(opts)>1: sys.exit('ambiguous status \"%s\": %s' % (want, [o['name'] for o in opts]))
+        print(f['id'], opts[0]['id'])
+")
+
+    local itemId
+    itemId="$($GH project item-list "$num" --owner "$o" --format json | TARGET="$target" $PY -c "
+import json,sys,os
+d=json.load(sys.stdin); t=str(os.environ['TARGET'])
+for it in d['items']:
+    c=it.get('content',{}) or {}
+    if str(c.get('number'))==t: print(it['id']); break
+else: sys.exit('item #%s not on board (run: board.sh add %s)' % (t,t))
+")
+
+    $GH project item-edit --id "$itemId" --project-id "$pid" \
+        --field-id "$fieldId" --single-select-option-id "$optId" >/dev/null
+    echo "set #$target Status -> match \"$want\""
+}
+
+case "${1:-}" in
+    info)   cmd_info ;;
+    list)   cmd_list ;;
+    add)    cmd_add "${2:?issue/PR number}" ;;
+    status) cmd_status "${2:?issue/PR number}" "${3:?status name}" ;;
+    *) echo "usage: board.sh {info|list|add <num>|status <num> <status>}" >&2; exit 2 ;;
+esac

--- a/.claude/skills/rt-tools-ship-pr/REFERENCE.md
+++ b/.claude/skills/rt-tools-ship-pr/REFERENCE.md
@@ -1,0 +1,100 @@
+# Reference — formats & templates
+
+## Unreleased CHANGELOG block
+
+Prepend above the latest released `## [x.y.z](...)` heading. Use only the
+sections that apply. Headings match conventional-changelog so a future release
+can fold them in cleanly.
+
+```md
+## [Unreleased]
+
+### Features
+
+- **<scope>:** <what the user can now do, in this project's own terms>
+
+### Bug Fixes
+
+- **<scope>:** <what was broken and is now fixed>
+
+### BREAKING CHANGES
+
+- **<scope>:** <what was removed/renamed> + the migration path
+```
+
+Rules:
+
+- `<scope>` mirrors the commit scope, e.g. `rt:ui-kit`.
+- One bullet per user-visible change, not per commit. Collapse `style`/`chore`/
+  `docs`-only commits — they don't earn a CHANGELOG line.
+- If `## [Unreleased]` already exists, extend its sections instead of adding a
+  second block.
+- Commit message: `docs(<scope>): add unreleased notes for <short summary>`.
+
+## PR body template
+
+Write to the session scratchpad, then `--body-file` it.
+
+```md
+## Summary
+
+<1–3 sentence what & why>
+
+- **<headline change>** — <detail: new API surface, inputs, behavior>
+
+## Changes
+
+- <file-group level bullets: added / removed / updated>
+
+## ⚠️ Breaking changes # omit the whole section if none
+
+<what breaks> and how to migrate:
+
+- `<old usage>` → `<new usage>`
+
+## Test plan
+
+- [ ] `pnpm run build:ui-kit`
+- [ ] `pnpm test`
+- [ ] `pnpm run lint`
+- [ ] <visual / Storybook check if UI changed>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+If the PR resolves a board task, add `Closes #<issue>` to the body so merging
+auto-closes the issue.
+
+## Commit trailer
+
+End every commit body with:
+
+```
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+## Commands cheat sheet
+
+```bash
+scripts/gather-context.sh main
+
+command git push -u origin "$(command git rev-parse --abbrev-ref HEAD)"
+
+command git add projects/ui-kit/CHANGELOG.md
+command git commit -m "docs(rt:ui-kit): add unreleased notes for ..."
+command git push
+
+command gh pr create --base main --head "<branch>" \
+  --title "<conventional title>" --body-file <scratchpad>/pr-body.md
+
+# update existing PR instead of duplicating
+command gh pr edit <number> --body-file <scratchpad>/pr-body.md
+```
+
+## Pitfalls
+
+- If bare `gh`/`git` errors with an account-selection message, prefix with
+  `command`.
+- `gh pr create` warns about uncommitted changes — fine as long as the dirty
+  files are intentional leftovers, not part of this PR. Never `git add .`.
+- Don't touch released CHANGELOG sections; only the `Unreleased` block.

--- a/.claude/skills/rt-tools-ship-pr/SKILL.md
+++ b/.claude/skills/rt-tools-ship-pr/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rt-tools-ship-pr
+description: Push the current branch and open a GitHub PR for this repo with a description derived from the full diff and commits, then add an Unreleased CHANGELOG section per affected package in a separate commit. Use when asked to push the branch and open a PR, ship a branch, create a pull request, or update release notes / CHANGELOG in this Angular monorepo. For linking the PR to a board task and moving its status, see the rt-tools-board skill.
+---
+
+# Ship a PR
+
+Push the current branch, open a PR with a thorough description, and record an
+**Unreleased** CHANGELOG entry for each affected package.
+
+## Conventions
+
+- Base branch is `main`. Each package has its own `projects/*/CHANGELOG.md`;
+  versions live in `projects/*/package.json`.
+- `CHANGELOG.md` is auto-generated at release from conventional commits — never
+  rewrite released sections. Only prepend/extend a `## [Unreleased]` block.
+- Stage files by explicit path; never `git add .` (avoid sweeping untracked junk).
+- If a bare `git`/`gh` errors with an account-selection message, prefix it with
+  `command` (e.g. `command gh ...`).
+
+## Workflow
+
+1. **Gather context** — run the helper once (paths relative to this skill dir):
+
+    ```bash
+    scripts/gather-context.sh main
+    ```
+
+    It reports: branch, upstream, existing PR, commits + bodies (`main..HEAD`),
+    diff stat, affected `projects/*`, their CHANGELOG/version, and dirty files.
+
+2. **Understand the changes** — read the diff and key changed files
+   (`command git diff main...HEAD`, then Read the important ones). Identify new
+   or changed public API, removed exports, and any **breaking changes**.
+
+3. **Push** — if no upstream: `command git push -u origin <branch>`.
+
+4. **Update CHANGELOG (separate docs commit)** — for each affected
+   `projects/*/CHANGELOG.md`, prepend/extend a `## [Unreleased]` block using the
+   conventional-changelog headings, commit only those files, and push. Format in
+   [REFERENCE.md](REFERENCE.md).
+
+5. **Open or update the PR** — write the body to a scratchpad file and pass it
+   with `--body-file`. If a PR already exists, `command gh pr edit <n> --body-file ...`
+   instead of creating a duplicate. Template in [REFERENCE.md](REFERENCE.md).
+
+6. **Report** — PR URL, affected packages, breaking changes, leftover dirty files.
+
+## Commit trailers
+
+End commit bodies with the assistant co-author trailer, and PR bodies with the
+standard generated-with footer (see [REFERENCE.md](REFERENCE.md)).

--- a/.claude/skills/rt-tools-ship-pr/scripts/gather-context.sh
+++ b/.claude/skills/rt-tools-ship-pr/scripts/gather-context.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Gather everything needed to push a branch, open a PR and update CHANGELOG.
+# Deterministic, single call.
+#
+# Some setups route bare git/gh through an account-selection shim that errors;
+# this script always calls them via `command` to bypass it.
+#
+# Usage: gather-context.sh [base-branch]   (base defaults to `main`)
+
+set -euo pipefail
+
+BASE="${1:-main}"
+GIT="command git"
+GH="command gh"
+
+branch="$($GIT rev-parse --abbrev-ref HEAD)"
+
+echo "=== BRANCH ==="
+echo "current: $branch"
+echo "base:    $BASE"
+
+echo
+echo "=== UPSTREAM ==="
+if $GIT rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    echo "tracking: $($GIT rev-parse --abbrev-ref --symbolic-full-name '@{u}')"
+else
+    echo "tracking: <none — needs: git push -u origin $branch>"
+fi
+
+echo
+echo "=== EXISTING PR ==="
+$GH pr view "$branch" --json number,url,state 2>/dev/null || echo "none"
+
+echo
+echo "=== COMMITS ($BASE..HEAD) ==="
+$GIT log "$BASE..HEAD" --format='%h %s'
+
+echo
+echo "=== FULL COMMIT BODIES ==="
+$GIT log "$BASE..HEAD" --format='--- %h%n%s%n%n%b'
+
+echo
+echo "=== DIFF STAT ($BASE...HEAD) ==="
+$GIT diff --stat "$BASE...HEAD"
+
+echo
+echo "=== AFFECTED projects/* ==="
+$GIT diff --name-only "$BASE...HEAD" \
+    | grep '^projects/' | cut -d/ -f1,2 | sort -u || echo "none"
+
+echo
+echo "=== CHANGELOG FILES IN AFFECTED PROJECTS ==="
+for proj in $($GIT diff --name-only "$BASE...HEAD" | grep '^projects/' | cut -d/ -f1,2 | sort -u); do
+    cl="$proj/CHANGELOG.md"
+    if [ -f "$cl" ]; then
+        ver="$(grep -m1 '"version"' "$proj/package.json" 2>/dev/null | sed 's/[^0-9.]//g' || true)"
+        echo "$cl  (package version: ${ver:-?})"
+        echo "  top line: $(head -1 "$cl")"
+    fi
+done
+
+echo
+echo "=== UNCOMMITTED / UNTRACKED (do NOT sweep into commits) ==="
+$GIT status --short || true


### PR DESCRIPTION
## Summary

Adds two project-scoped Claude Code skills under `.claude/skills/` so the
repo's PR and board workflow is reproducible by any contributor using Claude Code.

- **rt-tools-ship-pr** — push the branch, open a PR with a description derived
  from the full diff and commits, and add an `Unreleased` CHANGELOG section per
  affected package in a separate commit.
- **rt-tools-board** — every PR maps to a board task: pick or create the issue,
  branch as `type/<num>-<slug>`, add it to the board, and drive its Status
  (In progress on start, In review when the PR opens). Hands off to
  rt-tools-ship-pr for the push/PR/CHANGELOG step.

## Details

- Helper scripts (`gather-context.sh`, `board.sh`) resolve owner, board and
  field IDs at runtime — nothing account-specific is hardcoded, so they work in
  any clone.
- `.claude/settings.local.json` stays gitignored; only the shared skills are
  committed.

## Test plan

- [x] `board.sh info` / `board.sh list` run green against the board
- [x] `gather-context.sh` runs from the skill dir
- [ ] Skills appear in Claude Code's skill list for this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
