### PR TITLE
ci: re-sync pnpm-lock.yaml during publish to keep --frozen-lockfile green

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -50,6 +50,7 @@ jobs:
               run: |
                   node update-version-core.cjs ${{ github.event.inputs.version }}
                   pnpm run changelog:core
+                  pnpm install --lockfile-only
                   VERSION=$(jq -r .version projects/core/package.json)
                   echo "VERSION=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-store.yml
+++ b/.github/workflows/publish-store.yml
@@ -50,6 +50,7 @@ jobs:
               run: |
                   node update-version-store.cjs ${{ github.event.inputs.version }}
                   pnpm run changelog:store
+                  pnpm install --lockfile-only
                   VERSION=$(jq -r .version projects/store/package.json)
                   echo "VERSION=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-utils.yml
+++ b/.github/workflows/publish-utils.yml
@@ -50,6 +50,7 @@ jobs:
               run: |
                   node update-version-utils.cjs ${{ github.event.inputs.version }}
                   pnpm run changelog:utils
+                  pnpm install --lockfile-only
                   VERSION=$(jq -r .version projects/utils/package.json)
                   echo "VERSION=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
               run: |
                   node update-version.cjs ${{ github.event.inputs.version }}
                   pnpm run changelog:ui-kit
+                  pnpm install --lockfile-only
                   VERSION=$(jq -r .version projects/ui-kit/package.json)
                   echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Summary

Fixes the publish pipeline so multi-package releases no longer break on
`pnpm install --frozen-lockfile`.

The publish workflows bump package versions and cross-dependency ranges, then
commit and tag — but they never regenerated `pnpm-lock.yaml`. After one package
was published, the lockfile drifted from the bumped `package.json` versions, and
the next publish failed with:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date
```

This required a manual `pnpm install --lockfile-only` + commit between every
package in a release chain.

## Change

Add `pnpm install --lockfile-only` to the **Update version** step of all four
publish workflows (`publish-core`, `publish-store`, `publish-utils`, `publish`),
right after the version bump + changelog. `EndBug/add-and-commit` already stages
modified tracked files, so the refreshed lockfile is committed alongside the
version bump automatically — no extra `add:` path needed.

## Why this is enough

- `update-version-*.cjs` already updates dependents' cross-dep ranges, so by the
  time `--lockfile-only` runs the new versions and ranges are all on disk.
- The lockfile is committed in the same `[ci skip]` bump commit, so `main` stays
  consistent and the next publish's frozen install passes.

Closes #203

## Test plan

- [ ] Trigger two publish workflows in sequence (e.g. core then store) and
      confirm the second no longer fails on the frozen install.
- [ ] After a publish, `main`'s `pnpm-lock.yaml` matches the bumped versions
      (no follow-up sync commit needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
