### PR TITLE
feat(rt:ui-kit): add Material ripple to rtui-button

### DIFF
--- a/projects/ui-kit/CHANGELOG.md
+++ b/projects/ui-kit/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **rt:ui-kit:** unify all button variants into a single `rtui-button` component (`type` icon/fab/pill, `variant` default/primary/danger/success/warning/accent, `size` xs/sm/md/lg, `radius` none/sm/md/lg/full, `appearance` solid/outline/light/text) with built-in tooltip, loading spinner and icon slots
 - **rt:ui-kit:** add a standalone `rtui-icon` component (Material Symbols Outlined) with `size`, `theme`, `glyph`, `outlined` and `rotate` inputs plus font-load tracking
 - **rt:ui-kit:** add a transparent, borderless `text` appearance for every button colour, with a neutral hover wash via `--rt-bg-base-hover`
+- **rt:ui-kit:** add a Material ripple to `rtui-button` press feedback (disabled while loading/disabled, clipped to the button bounds)
 
 ### Bug Fixes
 

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
@@ -1,6 +1,13 @@
 @switch (type()) {
     @case ('pill') {
-        <button type="button" rtBlock="rtui-button" [rtMod]="modifiers()" [disabled]="disabled() || loading()" (click)="onClick()">
+        <button
+            type="button"
+            rtBlock="rtui-button"
+            matRipple
+            [rtMod]="modifiers()"
+            [matRippleDisabled]="disabled() || loading()"
+            [disabled]="disabled() || loading()"
+            (click)="onClick()">
             @if (loading()) {
                 <rtui-spinner rtElem="spinner" [diameter]="spinnerSize()" [showBox]="false" />
             } @else {
@@ -18,7 +25,14 @@
         </button>
     }
     @default {
-        <button type="button" rtBlock="rtui-button" [rtMod]="modifiers()" [disabled]="disabled() || loading()" (click)="onClick()">
+        <button
+            type="button"
+            rtBlock="rtui-button"
+            matRipple
+            [rtMod]="modifiers()"
+            [matRippleDisabled]="disabled() || loading()"
+            [disabled]="disabled() || loading()"
+            (click)="onClick()">
             @if (loading()) {
                 <rtui-spinner rtElem="spinner" [diameter]="spinnerSize()" [showBox]="false" />
             } @else {

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
@@ -14,6 +14,7 @@
 .rtui-button {
     position: relative;
     display: inline-flex;
+    overflow: hidden;
     align-items: center;
     justify-content: center;
     border: 0;

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
@@ -11,6 +11,7 @@ import {
     input,
     output,
 } from '@angular/core';
+import { MatRipple } from '@angular/material/core';
 import { MatTooltip } from '@angular/material/tooltip';
 
 import { BlockDirective, ElemDirective, ModDirective } from '@rt-tools/core';
@@ -42,6 +43,9 @@ export namespace IRtuiButton {
 
         // components
         RtuiIconComponent,
+
+        // material
+        MatRipple,
     ],
     hostDirectives: [
         {


### PR DESCRIPTION
## Summary

Adds a Material ripple to the unified `rtui-button` so clicks get a press-feedback animation.

## Changes

- Apply the `matRipple` directive to both the `pill` and default button variants.
- Bind `matRippleDisabled` to `disabled() || loading()` so the ripple is suppressed while the button is non-interactive.
- Add `overflow: hidden` to `.rtui-button` so the ripple is clipped to the button bounds and respects the `radius` modifier.
- Import `MatRipple` into the component.

## Affected packages

- `@rt-tools/ui-kit` — Unreleased CHANGELOG entry added.

## Breaking changes

None. The ripple is a purely additive visual enhancement; existing inputs and behaviour are unchanged.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
