### PR TITLE
feat(rt:ui-kit): add pinned group divider to multi-selector popup

### DIFF
--- a/projects/ui-kit/CHANGELOG.md
+++ b/projects/ui-kit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Features
+
+- **rt:ui-kit:** add a pinned-group divider to `rtui-multi-selector-popup` via a `pinnedKeys` input (trailing separator after the pinned options, in both radio and checkbox modes)
+
 ## [0.0.22](https://github.com/Eyhenij/rt-tools/compare/rt-tools@0.0.21...rt-tools@0.0.22) (2026-06-28)
 
 ### Features

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.html
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.html
@@ -90,6 +90,7 @@
                 @if (isSingleSelection()) {
                     <mat-radio-button
                         rtElem="item"
+                        [rtMod]="{ separated: entity[keyExp()] === lastSeparatedKey() }"
                         [checked]="selectionControl.value.includes(entity[keyExp()])"
                         (change)="onToggleSingleItem(entity, !selectionControl.value.includes(entity[keyExp()]))">
                         <div rtElem="item-title">
@@ -103,6 +104,7 @@
                 } @else {
                     <mat-checkbox
                         rtElem="item"
+                        [rtMod]="{ separated: entity[keyExp()] === lastSeparatedKey() }"
                         [checked]="selectionControl.value.includes(entity[keyExp()])"
                         (click)="onToggleItem($event, entity, !selectionControl.value.includes(entity[keyExp()]))">
                         <div rtElem="item-title">

--- a/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/dynamic-selectors/components/multi-selector-popup/rtui-multi-selector-popup.component.ts
@@ -3,6 +3,7 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
+    computed,
     DestroyRef,
     effect,
     ElementRef,
@@ -145,6 +146,10 @@ export class RtuiMultiSelectorPopupComponent<ENTITY extends Record<string, unkno
     public isLocalSearch: InputSignalWithTransform<Nullable<boolean>, boolean> = input<Nullable<boolean>, boolean>(true, {
         transform: booleanAttribute,
     });
+    /** Keys of a pinned group kept at the top of the list — a trailing divider is drawn after the last visible one */
+    public pinnedKeys: InputSignalWithTransform<ENTITY[KEY][], ENTITY[KEY][]> = input<ENTITY[KEY][], ENTITY[KEY][]>([], {
+        transform: (value: unknown) => transformArrayInput(value),
+    });
 
     /** Send output selected entities ids */
     public readonly submitAction: OutputEmitterRef<ENTITY[KEY][]> = output<ENTITY[KEY][]>();
@@ -175,6 +180,26 @@ export class RtuiMultiSelectorPopupComponent<ENTITY extends Record<string, unkno
     public readonly isMultiSelection: WritableSignal<boolean> = signal(true);
     /** Indicates is macOS used */
     public readonly isMacOS: Signal<boolean> = signal(this.#deviceService.getOS() === this.oSTypes.MAC_OS);
+    /** Key of the last visible pinned option — its row gets a trailing divider */
+    public readonly lastSeparatedKey: Signal<Nullable<ENTITY[KEY]>> = computed(() => {
+        const keys: ENTITY[KEY][] = this.pinnedKeys();
+
+        if (!keys.length) {
+            return null;
+        }
+
+        const list: ENTITY[] = this.filteredEntities();
+
+        for (let i: number = list.length - 1; i >= 0; i--) {
+            const key: ENTITY[KEY] = list[i][this.keyExp()];
+
+            if (keys.includes(key)) {
+                return key;
+            }
+        }
+
+        return null;
+    });
 
     public ngOnInit(): void {
         /** Clear previous temp selection  */


### PR DESCRIPTION
## Summary

Adds an optional pinned-group divider to `rtui-multi-selector-popup`. When a group of options is kept at the top of the list, a trailing separator is drawn after the last visible pinned option.

## Changes

- New `pinnedKeys` input (array of entity keys, normalised via `transformArrayInput`).
- `lastSeparatedKey` computed signal — the last pinned key still visible in the current filtered list.
- Apply the existing `separated` BEM modifier to that row, in both single (radio) and multi (checkbox) selection modes. Reuses the existing `--separated` border-bottom style — no new CSS.

## Affected packages

- `@rt-tools/ui-kit` — Unreleased CHANGELOG entry added.

## Breaking changes

None. `pinnedKeys` defaults to `[]`; with no pinned keys the behaviour is unchanged.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
