### PR TITLE
feat(rt:ui-kit): RT_UI_CONFIG with global/per-component defaults and a material design mode for rtui-button

### DIFF
--- a/docs/rt-ui-config-migration.md
+++ b/docs/rt-ui-config-migration.md
@@ -1,0 +1,102 @@
+# RT_UI_CONFIG — migration plan
+
+## Why
+
+The library currently renders controls from two visual generations:
+
+- **`rtui-*` design-system controls** (e.g. `rtui-button`) styled by the `--rt-*` design tokens — the target look;
+- **raw Material buttons hardcoded inside composite components** — e.g. the footers of
+  `rtui-aside-container` and `rtui-multi-selector-popup` use `mat-button` / `mat-flat-button`
+  (the latter still carrying the dead legacy `c-button` class and a hardcoded uppercase label).
+
+Consumer apps cannot pick which look they get, and the two looks diverge (height, radius,
+typography, colors). `RT_UI_CONFIG` makes the look a **consumer decision** at three levels:
+
+```
+instance input  >  components.<name>  >  global  >  library default
+```
+
+## The config (shipped in Phase 0)
+
+```typescript
+provideRtUi({
+    global: {
+        theme: 'auto', // initial theme when nothing is persisted
+        colorScheme: 'my-brand', // initial brand ramp when nothing is persisted
+        design: 'custom', // default design for every design-aware control
+    },
+    components: {
+        button: { design: 'material', size: 'md', radius: 'full', appearance: 'text' },
+    },
+});
+```
+
+- `RT_UI_CONFIG` is an `InjectionToken<IRtUiConfig.Config>` with a root factory of `{}` —
+  every setting is optional and the absence of the provider preserves today's behavior exactly.
+- `RtThemeService` uses `global.theme` / `global.colorScheme` as the _fallback_ when the user
+  has no persisted preference; a persisted choice always wins.
+- `rtui-button` resolves `design`, `size`, `radius`, `appearance` through the chain above.
+  `design: 'material'` renders the pill as an M3 filled button (`--mat-sys-primary`), and
+  `appearance: 'text'` under material as an M3 text button; `variant: 'danger'` maps to the
+  M3 error role. All other variants map to primary (M3 has no success/warning roles).
+
+## Phases
+
+### Phase 0 — foundation (this change)
+
+- `IRtUiConfig` types, `RT_UI_CONFIG` token, `provideRtUi(config?)` (backward compatible).
+- `rtui-button`: new `design` input (`'material' | 'custom'`, default `'custom'`),
+  config-resolved `size`/`radius`/`appearance`, `--design-*` BEM modifier, M3 style block.
+- `RtThemeService`: config-driven initial theme / color scheme.
+
+### Phase 1 — migrate composite-component footers onto `rtui-button`
+
+Replace the hardcoded Material buttons inside the library with `rtui-button` so the config
+governs them. Inventory (grep `mat-button|mat-flat-button|mat-stroked-button|c-button` in
+`projects/ui-kit/src/lib/ui-kit`):
+
+| Component                        | Spot                                 | Notes                                       |
+| -------------------------------- | ------------------------------------ | ------------------------------------------- |
+| `rtui-aside-container`           | footer Cancel/Submit                 | keep `cdkFocusInitial` on Cancel            |
+| `rtui-multi-selector-popup`      | footer Cancel/SUBMIT                 | drop `c-button` class + hardcoded uppercase |
+| `rtui-modal` footers             | confirm/cancel actions               | check all modal templates                   |
+| other spots surfaced by the grep | file/image uploaders, table controls | case by case                                |
+
+**Compatibility rule:** during Phase 1 these internal buttons resolve their design from the
+config with a **`'material'` fallback** (not the library default `'custom'`), so a consumer
+that upgrades without providing a config sees no visual change. Expose the knob as
+`components.aside.footerDesign` / `components.multiSelector.footerDesign` or, simpler, one
+shared `components.compositeFooters.design` — decide when the first footer migrates.
+
+### Phase 2 — extend `IRtUiConfig.Components` to the rest of the kit
+
+- Add entries for other design-aware components as real needs appear (aside, multi-selector,
+  table density, snack-bar). One entry per component, same resolution chain.
+- Factor the resolution into a tiny shared helper (`resolveUiSetting(input, componentCfg, globalCfg, fallback)`)
+  once a third component adopts the pattern — two copies are fine, three are not.
+- Every new entry ships with spec coverage of the resolution chain (see
+  `rtui-button.component.spec.ts` as the template).
+
+### Phase 3 — flip the transitional fallbacks
+
+Once consumers have had a release cycle to set `design` explicitly:
+
+- switch the Phase-1 internal fallbacks from `'material'` to the library default (`'custom'`),
+  in a **minor release with a loud changelog entry** — this is the visual cutover;
+- consumers that want to keep the Material look permanently set
+  `global.design: 'material'` (or per-component entries) and nothing changes for them.
+
+### Phase 4 — cleanup
+
+- Remove the dead `c-button` classes and hardcoded label casing from templates.
+- Deprecate (JSDoc `@deprecated`, one minor release) and then remove any per-component
+  inputs that merely duplicated what the config expresses better.
+- Storybook: add a global toolbar toggle that re-provides `RT_UI_CONFIG` so every story can
+  be viewed in both designs.
+
+## Testing per phase
+
+- Unit: resolution-chain specs per component (input > component entry > global > default).
+- Visual: Storybook story per migrated spot rendered in both designs.
+- Consumer smoke: build a consumer app against the local `dist/` before each publish and
+  verify no unconfigured visual diffs (the compatibility rule above is the contract).

--- a/projects/ui-kit/jest.config.ts
+++ b/projects/ui-kit/jest.config.ts
@@ -21,9 +21,7 @@ export default {
         'jest-preset-angular/build/serializers/html-comment',
     ],
     moduleNameMapper: {
-        '^@angular/cdk/overlay$': '<rootDir>/../../node_modules/@angular/cdk/fesm2022/overlay.mjs',
-        '^@angular/cdk/layout$': '<rootDir>/../../node_modules/@angular/cdk/fesm2022/layout.mjs',
-        '^@angular/cdk/coercion$': '<rootDir>/../../node_modules/@angular/cdk/fesm2022/coercion.mjs',
-        '^@angular/cdk/portal$': '<rootDir>/../../node_modules/@angular/cdk/fesm2022/portal.mjs',
+        '^@angular/cdk/([\\w-]+)$': '<rootDir>/../../node_modules/@angular/cdk/fesm2022/$1.mjs',
+        '^@angular/material/([\\w-]+)$': '<rootDir>/../../node_modules/@angular/material/fesm2022/$1.mjs',
     },
 };

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
@@ -245,4 +245,72 @@
             background-color: var(--rt-bg-base-hover);
         }
     }
+
+    /* ===================== design: material =====================
+       Classic Material (M3) look, opted in per instance ([design]="'material'")
+       or app-wide via the RT_UI_CONFIG provider. Renders the pill as an M3
+       filled button; `appearance-text` renders as an M3 text button. Variants
+       map onto the Material theme: `danger` -> error, everything else -> primary
+       (M3 has no success/warning roles). These rules come after the custom-look
+       blocks on purpose: equal-or-higher specificity wins by source order. */
+    &--type-pill.rtui-button--design-material {
+        min-height: 2.5rem;
+        padding: 0 var(--mat-button-filled-horizontal-padding, 1.5rem);
+        border-radius: var(--mat-sys-corner-full, 1.25rem);
+        background-color: var(--mat-sys-primary);
+        color: var(--mat-sys-on-primary);
+        font-size: var(--mat-sys-label-large-size, 0.875rem);
+        font-weight: var(--mat-sys-label-large-weight, 500);
+
+        &:hover:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-primary) 92%, var(--mat-sys-on-primary));
+        }
+
+        &:active:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-primary) 84%, var(--mat-sys-on-primary));
+        }
+    }
+
+    &--type-pill.rtui-button--design-material.rtui-button--variant-danger {
+        background-color: var(--mat-sys-error);
+        color: var(--mat-sys-on-error);
+
+        &:hover:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-error) 92%, var(--mat-sys-on-error));
+        }
+
+        &:active:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-error) 84%, var(--mat-sys-on-error));
+        }
+    }
+
+    &--type-pill.rtui-button--design-material.rtui-button--appearance-text {
+        min-height: 2.5rem;
+        padding: 0 var(--mat-button-text-horizontal-padding, 0.75rem);
+        background-color: transparent;
+        color: var(--mat-sys-primary);
+        font-size: var(--mat-sys-label-large-size, 0.875rem);
+        font-weight: var(--mat-sys-label-large-weight, 500);
+
+        &:hover:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-primary) 8%, transparent);
+        }
+
+        &:active:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
+        }
+    }
+
+    &--type-pill.rtui-button--design-material.rtui-button--variant-danger.rtui-button--appearance-text {
+        background-color: transparent;
+        color: var(--mat-sys-error);
+
+        &:hover:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-error) 8%, transparent);
+        }
+
+        &:active:not(:disabled) {
+            background-color: color-mix(in srgb, var(--mat-sys-error) 12%, transparent);
+        }
+    }
 }

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IRtUiConfig, RT_UI_CONFIG } from '../../config';
+import { RtuiButtonComponent } from './rtui-button.component';
+
+describe('RtuiButtonComponent', () => {
+    function setup(config?: IRtUiConfig.Config): ComponentFixture<RtuiButtonComponent> {
+        TestBed.configureTestingModule({
+            imports: [RtuiButtonComponent],
+            providers: [{ provide: RT_UI_CONFIG, useValue: config ?? {} }],
+        });
+
+        const fixture: ComponentFixture<RtuiButtonComponent> = TestBed.createComponent(RtuiButtonComponent);
+        fixture.componentRef.setInput('type', 'pill');
+        fixture.detectChanges();
+
+        return fixture;
+    }
+
+    function buttonClasses(fixture: ComponentFixture<RtuiButtonComponent>): DOMTokenList {
+        return (fixture.nativeElement as HTMLElement).querySelector('button')!.classList;
+    }
+
+    it('defaults to the custom design, md size and full radius without any config', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup();
+        const classes: DOMTokenList = buttonClasses(fixture);
+
+        expect(classes.contains('rtui-button--design-custom')).toBe(true);
+        expect(classes.contains('rtui-button--size-md')).toBe(true);
+        expect(classes.contains('rtui-button--radius-full')).toBe(true);
+    });
+
+    it('applies component-level config defaults (design, size, appearance)', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({
+            components: { button: { design: 'material', size: 'lg', appearance: 'text' } },
+        });
+        const classes: DOMTokenList = buttonClasses(fixture);
+
+        expect(classes.contains('rtui-button--design-material')).toBe(true);
+        expect(classes.contains('rtui-button--size-lg')).toBe(true);
+        expect(classes.contains('rtui-button--appearance-text')).toBe(true);
+    });
+
+    it('falls back to the global design when the button entry does not set one', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({ global: { design: 'material' } });
+
+        expect(buttonClasses(fixture).contains('rtui-button--design-material')).toBe(true);
+    });
+
+    it('prefers the component entry over the global default', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({
+            global: { design: 'material' },
+            components: { button: { design: 'custom' } },
+        });
+
+        expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
+    });
+
+    it('lets the instance input override every config level', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({
+            global: { design: 'material' },
+            components: { button: { design: 'material' } },
+        });
+        fixture.componentRef.setInput('design', 'custom');
+        fixture.detectChanges();
+
+        expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
+    });
+
+    it('lets explicit size/radius inputs override the config defaults', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({
+            components: { button: { size: 'lg', radius: 'none' } },
+        });
+        fixture.componentRef.setInput('size', 'xs');
+        fixture.componentRef.setInput('radius', 'sm');
+        fixture.detectChanges();
+
+        const classes: DOMTokenList = buttonClasses(fixture);
+        expect(classes.contains('rtui-button--size-xs')).toBe(true);
+        expect(classes.contains('rtui-button--radius-sm')).toBe(true);
+    });
+});

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
@@ -8,6 +8,7 @@ import {
     Signal,
     booleanAttribute,
     computed,
+    inject,
     input,
     output,
 } from '@angular/core';
@@ -17,6 +18,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { BlockDirective, ElemDirective, ModDirective } from '@rt-tools/core';
 import { transformStringInput } from '@rt-tools/utils';
 
+import { IRtUiConfig, RT_UI_CONFIG, RtUiDesign } from '../../config';
 import { RtuiIconComponent, RtuiIconSizeType } from '../../icon';
 import { RtuiSpinnerComponent } from '../../spinner';
 
@@ -63,6 +65,19 @@ export namespace IRtuiButton {
     },
 })
 export class RtuiButtonComponent {
+    /** App-wide defaults; the resolution order is: instance input → `components.button` → `global` → library default. */
+    readonly #config: IRtUiConfig.Config = inject(RT_UI_CONFIG);
+    readonly #buttonConfig: IRtUiConfig.Button | undefined = this.#config.components?.button;
+
+    /** Design system the button renders with — see {@link RtUiDesign}. */
+    protected readonly resolvedDesign: Signal<RtUiDesign> = computed(
+        () => this.design() ?? this.#buttonConfig?.design ?? this.#config.global?.design ?? 'custom'
+    );
+    protected readonly resolvedSize: Signal<IRtuiButton.Size> = computed(() => this.size() ?? this.#buttonConfig?.size ?? 'md');
+    protected readonly resolvedRadius: Signal<IRtuiButton.Radius> = computed(() => this.radius() ?? this.#buttonConfig?.radius ?? 'full');
+    protected readonly resolvedAppearance: Signal<IRtuiButton.Appearance | undefined> = computed(
+        () => this.appearance() ?? this.#buttonConfig?.appearance
+    );
     protected readonly resolvedIconSize: Signal<RtuiIconSizeType> = computed(() => {
         const iconSize: RtuiIconSizeType | undefined = this.iconSize();
 
@@ -76,7 +91,7 @@ export class RtuiButtonComponent {
             md: 'sm',
             lg: 'md',
         };
-        return sizeMap[this.size()];
+        return sizeMap[this.resolvedSize()];
     });
     protected readonly spinnerSize: Signal<number> = computed(() => {
         const sizeMap: Record<IRtuiButton.Size, number> = {
@@ -85,23 +100,25 @@ export class RtuiButtonComponent {
             md: 20,
             lg: 24,
         };
-        return this.spinnerDiameter() ?? sizeMap[this.size()];
+        return this.spinnerDiameter() ?? sizeMap[this.resolvedSize()];
     });
     protected readonly modifiers: Signal<Record<string, boolean>> = computed(() => ({
         [`type-${this.type()}`]: true,
+        [`design-${this.resolvedDesign()}`]: true,
         [`variant-${this.variant()}`]: true,
-        [`size-${this.size()}`]: true,
-        [`radius-${this.radius()}`]: true,
-        [`appearance-${this.appearance()}`]: !!this.appearance(),
+        [`size-${this.resolvedSize()}`]: true,
+        [`radius-${this.resolvedRadius()}`]: true,
+        [`appearance-${this.resolvedAppearance()}`]: !!this.resolvedAppearance(),
         loading: this.loading(),
         disabled: this.disabled(),
     }));
 
     public readonly type: InputSignal<IRtuiButton.Type> = input<IRtuiButton.Type>('icon');
+    public readonly design: InputSignal<RtUiDesign | undefined> = input<RtUiDesign>();
     public readonly variant: InputSignal<IRtuiButton.Variant> = input<IRtuiButton.Variant>('default');
     public readonly appearance: InputSignal<IRtuiButton.Appearance | undefined> = input<IRtuiButton.Appearance>();
-    public readonly size: InputSignal<IRtuiButton.Size> = input<IRtuiButton.Size>('md');
-    public readonly radius: InputSignal<IRtuiButton.Radius> = input<IRtuiButton.Radius>('full');
+    public readonly size: InputSignal<IRtuiButton.Size | undefined> = input<IRtuiButton.Size>();
+    public readonly radius: InputSignal<IRtuiButton.Radius | undefined> = input<IRtuiButton.Radius>();
     public readonly icon: InputSignalWithTransform<string, unknown> = input<string, unknown>('', { transform: transformStringInput });
     public readonly iconPosition: InputSignal<IRtuiButton.IconPosition> = input<IRtuiButton.IconPosition>('start');
     public readonly iconSize: InputSignal<RtuiIconSizeType | undefined> = input<RtuiIconSizeType>();

--- a/projects/ui-kit/src/lib/ui-kit/config/index.ts
+++ b/projects/ui-kit/src/lib/ui-kit/config/index.ts
@@ -1,0 +1,1 @@
+export * from './rt-ui-config';

--- a/projects/ui-kit/src/lib/ui-kit/config/rt-ui-config.ts
+++ b/projects/ui-kit/src/lib/ui-kit/config/rt-ui-config.ts
@@ -1,0 +1,70 @@
+import { InjectionToken } from '@angular/core';
+
+import type { IRtuiButton } from '../buttons/unified-button/rtui-button.component';
+import type { RtThemeType } from '../theme/rtui-theme.types';
+
+/**
+ * Design system a control renders with:
+ * - `'custom'` — the rt-tools look (design tokens, pill shapes). The default.
+ * - `'material'` — the classic Material (M3) look, for apps that have not migrated
+ *   their visual language yet or need to match surrounding Material controls.
+ */
+export type RtUiDesign = 'material' | 'custom';
+
+export namespace IRtUiConfig {
+    /** Global defaults applied app-wide unless a component-level setting or an input overrides them. */
+    export interface Global {
+        /** Initial theme used when the user has no persisted preference. */
+        theme?: RtThemeType;
+        /** Initial brand color scheme (see `RtThemeService.registerColorScheme`) when none is persisted. */
+        colorScheme?: string;
+        /** Default design for every design-aware control. */
+        design?: RtUiDesign;
+    }
+
+    /** Per-instance-overridable defaults for `rtui-button`. */
+    export interface Button {
+        design?: RtUiDesign;
+        size?: IRtuiButton.Size;
+        radius?: IRtuiButton.Radius;
+        appearance?: IRtuiButton.Appearance;
+    }
+
+    /** Component-level settings. Each entry overrides `global` for that component only. */
+    export interface Components {
+        button?: Button;
+    }
+
+    export interface Config {
+        global?: Global;
+        components?: Components;
+    }
+}
+
+/**
+ * Application-wide UI configuration for rt-tools components.
+ *
+ * Resolution order (most specific wins):
+ * 1. the component input on a concrete instance,
+ * 2. `components.<name>` in this config,
+ * 3. `global` in this config,
+ * 4. the library default.
+ *
+ * Provide it via {@link provideRtUi}:
+ * ```typescript
+ * bootstrapApplication(RootComponent, {
+ *     providers: [
+ *         provideRtUi({
+ *             global: { theme: 'auto', design: 'custom' },
+ *             components: { button: { design: 'material' } },
+ *         }),
+ *     ],
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export const RT_UI_CONFIG: InjectionToken<IRtUiConfig.Config> = new InjectionToken<IRtUiConfig.Config>('RT_UI_CONFIG', {
+    providedIn: 'root',
+    factory: (): IRtUiConfig.Config => ({}),
+});

--- a/projects/ui-kit/src/lib/ui-kit/providers.ts
+++ b/projects/ui-kit/src/lib/ui-kit/providers.ts
@@ -2,20 +2,27 @@ import { Provider } from '@angular/core';
 
 import { RtActionBarService } from './action-bar';
 import { RtAsideService } from './aside';
+import { IRtUiConfig, RT_UI_CONFIG } from './config';
 
 /**
  * Returns a set of the necessary dependency injection providers for managing the UI.
  *
+ * Optionally accepts an application-wide {@link RT_UI_CONFIG UI configuration} with
+ * global theme/design defaults and per-component settings:
+ *
  * ```typescript
  * bootstrapApplication(RootComponent, {
  *   providers: [
- *     provideRtUi()
+ *     provideRtUi({
+ *       global: { theme: 'auto', design: 'custom' },
+ *       components: { button: { design: 'material' } },
+ *     })
  *   ]
  * });
  * ```
  *
  * @publicApi
  */
-export function provideRtUi(): Provider[] {
-    return [RtAsideService, RtActionBarService];
+export function provideRtUi(config?: IRtUiConfig.Config): Provider[] {
+    return [RtAsideService, RtActionBarService, { provide: RT_UI_CONFIG, useValue: config ?? {} }];
 }

--- a/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
+++ b/projects/ui-kit/src/lib/ui-kit/theme/rtui-theme.service.ts
@@ -3,6 +3,7 @@ import { effect, inject, Injectable, Signal, signal, WritableSignal } from '@ang
 
 import { LOCAL_STORAGE, PlatformService } from '@rt-tools/core';
 
+import { IRtUiConfig, RT_UI_CONFIG } from '../config';
 import {
     RT_ACCENT_ROLE_ENUM,
     RT_COLOR_SCHEME_STORAGE_KEY,
@@ -36,6 +37,8 @@ export class RtThemeService {
     readonly #platformService: PlatformService = inject(PlatformService);
     // falls back to the native localStorage when the app does not call provideRtStorage()
     readonly #storage: Storage | null = inject(LOCAL_STORAGE, { optional: true }) ?? this.#document.defaultView?.localStorage ?? null;
+    // app-wide defaults (provideRtUi(config)); a persisted user choice always wins over them
+    readonly #config: IRtUiConfig.Config = inject(RT_UI_CONFIG);
 
     readonly #theme: WritableSignal<RtThemeType> = signal<RtThemeType>(this.#restore());
     readonly #colorScheme: WritableSignal<string | null> = signal<string | null>(this.#restoreScheme());
@@ -109,23 +112,27 @@ export class RtThemeService {
     }
 
     #restore(): RtThemeType {
+        const fallback: RtThemeType = this.#config.global?.theme ?? RT_THEME_ENUM.LIGHT;
+
         if (!this.#platformService.isPlatformBrowser || !this.#storage) {
-            return RT_THEME_ENUM.LIGHT;
+            return fallback;
         }
 
         const stored: string | null = this.#storage.getItem(RT_THEME_STORAGE_KEY);
 
-        return Object.values(RT_THEME_ENUM).includes(stored as RT_THEME_ENUM) ? (stored as RtThemeType) : RT_THEME_ENUM.LIGHT;
+        return Object.values(RT_THEME_ENUM).includes(stored as RT_THEME_ENUM) ? (stored as RtThemeType) : fallback;
     }
 
     #restoreScheme(): string | null {
+        const fallback: string | null = this.#config.global?.colorScheme ?? null;
+
         if (!this.#platformService.isPlatformBrowser || !this.#storage) {
-            return null;
+            return fallback;
         }
 
         const stored: string | null = this.#storage.getItem(RT_COLOR_SCHEME_STORAGE_KEY);
 
-        return stored && stored !== RT_DEFAULT_SCHEME ? stored : null;
+        return stored && stored !== RT_DEFAULT_SCHEME ? stored : fallback;
     }
 
     #apply(theme: RtThemeType): void {

--- a/projects/ui-kit/src/public-api.ts
+++ b/projects/ui-kit/src/public-api.ts
@@ -14,6 +14,7 @@ export * from './lib/ui-kit/toolbar';
 export * from './lib/ui-kit/header';
 export * from './lib/ui-kit/table';
 export * from './lib/ui-kit/providers';
+export * from './lib/ui-kit/config';
 export * from './lib/ui-kit/snack-bar';
 export * from './lib/ui-kit/animation';
 export * from './lib/ui-kit/info-badge';

--- a/projects/ui-kit/tsconfig.spec.json
+++ b/projects/ui-kit/tsconfig.spec.json
@@ -14,10 +14,8 @@
             "@rt-tools/store": ["../store/src/index.ts"],
             "@rt-tools/utils": ["../utils/src/index.ts"],
             "@angular/core/testing": ["../../node_modules/@angular/core/types/testing.d.ts"],
-            "@angular/cdk/overlay": ["../../node_modules/@angular/cdk/types/overlay.d.ts"],
-            "@angular/cdk/layout": ["../../node_modules/@angular/cdk/types/layout.d.ts"],
-            "@angular/cdk/coercion": ["../../node_modules/@angular/cdk/types/coercion.d.ts"],
-            "@angular/cdk/portal": ["../../node_modules/@angular/cdk/types/portal.d.ts"]
+            "@angular/cdk/*": ["../../node_modules/@angular/cdk/types/*.d.ts"],
+            "@angular/material/*": ["../../node_modules/@angular/material/types/*.d.ts"]
         }
     },
     "files": ["src/test-setup.ts"],


### PR DESCRIPTION
## Summary

- New `RT_UI_CONFIG` injection token + `provideRtUi(config?)` (backward compatible): app-wide UI configuration with `global` settings (initial theme, color scheme, default design) and per-component entries (`components.button`: design/size/radius/appearance). Resolution order: instance input > component entry > global > library default.
- `rtui-button`: new `design` input (`'material' | 'custom'`, default `'custom'`), config-resolved `size`/`radius`/`appearance`, new `--design-*` BEM modifier. Material mode renders the pill as an M3 filled button (error role for `danger`), and `appearance-text` as an M3 text button; metrics hook into `--mat-button-*` / `--mat-sys-label-large-*` tokens with fallbacks.
- `RtThemeService`: `global.theme` / `global.colorScheme` act as fallbacks when the user has no persisted preference.
- Jest infra fix: wildcard `@angular/cdk|material/*` maps in `tsconfig.spec.json` (types) and `jest.config.ts` (fesm2022 runtime) — component specs importing Material could not run before.
- Migration plan: `docs/rt-ui-config-migration.md` (phases: composite footers onto rtui-button with a transitional material fallback, config coverage for the rest of the kit, the visual cutover, cleanup).

## Verification

- `nx build @rt-tools/ui-kit` — green.
- Tests 23/23 (6 new resolution-chain specs for the button).
- Lint green; stylelint: no new violations (28 pre-existing in the button SCSS unchanged).
