### PR TITLE
feat(rt:ui-kit): render the material button design via the native Material button

### DIFF
--- a/docs/rt-ui-config-migration.md
+++ b/docs/rt-ui-config-migration.md
@@ -36,9 +36,12 @@ provideRtUi({
 - `RtThemeService` uses `global.theme` / `global.colorScheme` as the _fallback_ when the user
   has no persisted preference; a persisted choice always wins.
 - `rtui-button` resolves `design`, `size`, `radius`, `appearance` through the chain above.
-  `design: 'material'` renders the pill as an M3 filled button (`--mat-sys-primary`), and
-  `appearance: 'text'` under material as an M3 text button; `variant: 'danger'` maps to the
-  M3 error role. All other variants map to primary (M3 has no success/warning roles).
+  `design: 'material'` renders the pill as a NATIVE Angular Material button (`matButton`) —
+  the Material theme fully owns its look. The rt appearances map onto the native ones:
+  `solid` → `filled` (the default), `outline` → `outlined`, `light` → `tonal`, `text` → `text`.
+  `variant: 'danger'` re-points the button's theme tokens at the M3 error role; all other
+  variants keep the theme primary (M3 has no success/warning roles). `size`/`radius` are
+  custom-design knobs and have no effect under material.
 
 ## Phases
 
@@ -46,7 +49,8 @@ provideRtUi({
 
 - `IRtUiConfig` types, `RT_UI_CONFIG` token, `provideRtUi(config?)` (backward compatible).
 - `rtui-button`: new `design` input (`'material' | 'custom'`, default `'custom'`),
-  config-resolved `size`/`radius`/`appearance`, `--design-*` BEM modifier, M3 style block.
+  config-resolved `size`/`radius`/`appearance`; under material the pill template renders
+  a native `matButton` instead of the custom-styled button.
 - `RtThemeService`: config-driven initial theme / color scheme.
 
 ### Phase 1 — migrate composite-component footers onto `rtui-button`

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
@@ -1,28 +1,54 @@
 @switch (type()) {
     @case ('pill') {
-        <button
-            type="button"
-            rtBlock="rtui-button"
-            matRipple
-            [rtMod]="modifiers()"
-            [matRippleDisabled]="disabled() || loading()"
-            [disabled]="disabled() || loading()"
-            (click)="onClick()">
-            @if (loading()) {
-                <rtui-spinner rtElem="spinner" [diameter]="spinnerSize()" [showBox]="false" />
-            } @else {
-                @if (icon() && iconPosition() === 'start') {
-                    <rtui-icon rtElem="icon" [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
+        @if (resolvedDesign() === 'material') {
+            <!-- design: material — a native Material button; its look is owned by the Material theme -->
+            <button
+                type="button"
+                class="rtui-button-material"
+                [matButton]="materialAppearance()"
+                [class.rtui-button-material--danger]="variant() === 'danger'"
+                [disabled]="disabled() || loading()"
+                (click)="onClick()">
+                @if (loading()) {
+                    <rtui-spinner [diameter]="spinnerSize()" [showBox]="false" />
+                } @else {
+                    @if (icon() && iconPosition() === 'start') {
+                        <rtui-icon matButtonIcon [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
+                    }
+                    @if (text()) {
+                        <span>{{ text() }}</span>
+                    }
+                    <ng-content />
+                    @if (icon() && iconPosition() === 'end') {
+                        <rtui-icon matButtonIcon iconPositionEnd [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
+                    }
                 }
-                @if (text()) {
-                    <span rtElem="text">{{ text() }}</span>
+            </button>
+        } @else {
+            <button
+                type="button"
+                rtBlock="rtui-button"
+                matRipple
+                [rtMod]="modifiers()"
+                [matRippleDisabled]="disabled() || loading()"
+                [disabled]="disabled() || loading()"
+                (click)="onClick()">
+                @if (loading()) {
+                    <rtui-spinner rtElem="spinner" [diameter]="spinnerSize()" [showBox]="false" />
+                } @else {
+                    @if (icon() && iconPosition() === 'start') {
+                        <rtui-icon rtElem="icon" [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
+                    }
+                    @if (text()) {
+                        <span rtElem="text">{{ text() }}</span>
+                    }
+                    <ng-content />
+                    @if (icon() && iconPosition() === 'end') {
+                        <rtui-icon rtElem="icon" [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
+                    }
                 }
-                <ng-content />
-                @if (icon() && iconPosition() === 'end') {
-                    <rtui-icon rtElem="icon" [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
-                }
-            }
-        </button>
+            </button>
+        }
     }
     @default {
         <button

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.scss
@@ -6,7 +6,8 @@
     display: block;
     width: 100%;
 
-    .rtui-button {
+    .rtui-button,
+    .rtui-button-material {
         width: 100%;
     }
 }
@@ -103,11 +104,11 @@
 
     /* ===================== pill ===================== */
     &--type-pill {
-        gap: 0.375rem;
         border-radius: 1.5rem;
         background-color: var(--mat-sys-surface-container-high);
         color: var(--mat-sys-on-surface-variant);
         font-weight: 500;
+        gap: 0.375rem;
 
         &:hover:not(:disabled) {
             background-color: var(--mat-sys-surface-container-highest);
@@ -245,72 +246,36 @@
             background-color: var(--rt-bg-base-hover);
         }
     }
+}
 
-    /* ===================== design: material =====================
-       Classic Material (M3) look, opted in per instance ([design]="'material'")
-       or app-wide via the RT_UI_CONFIG provider. Renders the pill as an M3
-       filled button; `appearance-text` renders as an M3 text button. Variants
-       map onto the Material theme: `danger` -> error, everything else -> primary
-       (M3 has no success/warning roles). These rules come after the custom-look
-       blocks on purpose: equal-or-higher specificity wins by source order. */
-    &--type-pill.rtui-button--design-material {
-        min-height: 2.5rem;
-        padding: 0 var(--mat-button-filled-horizontal-padding, 1.5rem);
-        border-radius: var(--mat-sys-corner-full, 1.25rem);
-        background-color: var(--mat-sys-primary);
-        color: var(--mat-sys-on-primary);
-        font-size: var(--mat-sys-label-large-size, 0.875rem);
-        font-weight: var(--mat-sys-label-large-weight, 500);
-
-        &:hover:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-primary) 92%, var(--mat-sys-on-primary));
-        }
-
-        &:active:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-primary) 84%, var(--mat-sys-on-primary));
-        }
+/* ===================== design: material =====================
+   Under `design: 'material'` the pill renders a NATIVE Material button (see the
+   template) whose look is fully owned by the Material theme. The only styling
+   the library adds is the variant mapping: `danger` re-points the button's own
+   theme tokens at the M3 error role (M3 has no success/warning roles, so every
+   other variant keeps the theme primary). */
+.rtui-button-material {
+    rtui-spinner {
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 
-    &--type-pill.rtui-button--design-material.rtui-button--variant-danger {
-        background-color: var(--mat-sys-error);
-        color: var(--mat-sys-on-error);
-
-        &:hover:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-error) 92%, var(--mat-sys-on-error));
-        }
-
-        &:active:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-error) 84%, var(--mat-sys-on-error));
-        }
-    }
-
-    &--type-pill.rtui-button--design-material.rtui-button--appearance-text {
-        min-height: 2.5rem;
-        padding: 0 var(--mat-button-text-horizontal-padding, 0.75rem);
-        background-color: transparent;
-        color: var(--mat-sys-primary);
-        font-size: var(--mat-sys-label-large-size, 0.875rem);
-        font-weight: var(--mat-sys-label-large-weight, 500);
-
-        &:hover:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-primary) 8%, transparent);
-        }
-
-        &:active:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
-        }
-    }
-
-    &--type-pill.rtui-button--design-material.rtui-button--variant-danger.rtui-button--appearance-text {
-        background-color: transparent;
-        color: var(--mat-sys-error);
-
-        &:hover:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-error) 8%, transparent);
-        }
-
-        &:active:not(:disabled) {
-            background-color: color-mix(in srgb, var(--mat-sys-error) 12%, transparent);
-        }
+    &--danger {
+        --mat-button-filled-container-color: var(--mat-sys-error);
+        --mat-button-filled-label-text-color: var(--mat-sys-on-error);
+        --mat-button-filled-state-layer-color: var(--mat-sys-on-error);
+        --mat-button-filled-ripple-color: color-mix(in srgb, var(--mat-sys-on-error) 12%, transparent);
+        --mat-button-outlined-label-text-color: var(--mat-sys-error);
+        --mat-button-outlined-outline-color: var(--mat-sys-error);
+        --mat-button-outlined-state-layer-color: var(--mat-sys-error);
+        --mat-button-outlined-ripple-color: color-mix(in srgb, var(--mat-sys-error) 12%, transparent);
+        --mat-button-text-label-text-color: var(--mat-sys-error);
+        --mat-button-text-state-layer-color: var(--mat-sys-error);
+        --mat-button-text-ripple-color: color-mix(in srgb, var(--mat-sys-error) 12%, transparent);
+        --mat-button-tonal-container-color: var(--mat-sys-error-container);
+        --mat-button-tonal-label-text-color: var(--mat-sys-on-error-container);
+        --mat-button-tonal-state-layer-color: var(--mat-sys-on-error-container);
+        --mat-button-tonal-ripple-color: color-mix(in srgb, var(--mat-sys-on-error-container) 12%, transparent);
     }
 }

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButton } from '@angular/material/button';
+import { By } from '@angular/platform-browser';
 
 import { IRtUiConfig, RT_UI_CONFIG } from '../../config';
 import { RtuiButtonComponent } from './rtui-button.component';
@@ -21,30 +23,48 @@ describe('RtuiButtonComponent', () => {
         return (fixture.nativeElement as HTMLElement).querySelector('button')!.classList;
     }
 
+    function matButton(fixture: ComponentFixture<RtuiButtonComponent>): MatButton | undefined {
+        return fixture.debugElement.query(By.directive(MatButton))?.componentInstance as MatButton | undefined;
+    }
+
     it('defaults to the custom design, md size and full radius without any config', () => {
         const fixture: ComponentFixture<RtuiButtonComponent> = setup();
         const classes: DOMTokenList = buttonClasses(fixture);
 
+        expect(matButton(fixture)).toBeUndefined();
         expect(classes.contains('rtui-button--design-custom')).toBe(true);
         expect(classes.contains('rtui-button--size-md')).toBe(true);
         expect(classes.contains('rtui-button--radius-full')).toBe(true);
     });
 
-    it('applies component-level config defaults (design, size, appearance)', () => {
+    it('renders a native Material button with the mapped appearance under a component-level material design', () => {
         const fixture: ComponentFixture<RtuiButtonComponent> = setup({
-            components: { button: { design: 'material', size: 'lg', appearance: 'text' } },
+            components: { button: { design: 'material', appearance: 'text' } },
         });
-        const classes: DOMTokenList = buttonClasses(fixture);
 
-        expect(classes.contains('rtui-button--design-material')).toBe(true);
-        expect(classes.contains('rtui-button--size-lg')).toBe(true);
-        expect(classes.contains('rtui-button--appearance-text')).toBe(true);
+        expect(buttonClasses(fixture).contains('rtui-button-material')).toBe(true);
+        expect(matButton(fixture)?.appearance).toBe('text');
+    });
+
+    it('maps the appearance onto the native Material appearances (solid -> filled by default)', () => {
+        const fixture: ComponentFixture<RtuiButtonComponent> = setup({ global: { design: 'material' } });
+
+        expect(matButton(fixture)?.appearance).toBe('filled');
+
+        fixture.componentRef.setInput('appearance', 'outline');
+        fixture.detectChanges();
+        expect(matButton(fixture)?.appearance).toBe('outlined');
+
+        fixture.componentRef.setInput('appearance', 'light');
+        fixture.detectChanges();
+        expect(matButton(fixture)?.appearance).toBe('tonal');
     });
 
     it('falls back to the global design when the button entry does not set one', () => {
         const fixture: ComponentFixture<RtuiButtonComponent> = setup({ global: { design: 'material' } });
 
-        expect(buttonClasses(fixture).contains('rtui-button--design-material')).toBe(true);
+        expect(matButton(fixture)).toBeDefined();
+        expect(buttonClasses(fixture).contains('rtui-button-material')).toBe(true);
     });
 
     it('prefers the component entry over the global default', () => {
@@ -53,6 +73,7 @@ describe('RtuiButtonComponent', () => {
             components: { button: { design: 'custom' } },
         });
 
+        expect(matButton(fixture)).toBeUndefined();
         expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
     });
 
@@ -64,6 +85,7 @@ describe('RtuiButtonComponent', () => {
         fixture.componentRef.setInput('design', 'custom');
         fixture.detectChanges();
 
+        expect(matButton(fixture)).toBeUndefined();
         expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
     });
 

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
@@ -12,6 +12,7 @@ import {
     input,
     output,
 } from '@angular/core';
+import { MatButton, MatButtonAppearance } from '@angular/material/button';
 import { MatRipple } from '@angular/material/core';
 import { MatTooltip } from '@angular/material/tooltip';
 
@@ -47,6 +48,7 @@ export namespace IRtuiButton {
         RtuiIconComponent,
 
         // material
+        MatButton,
         MatRipple,
     ],
     hostDirectives: [
@@ -78,6 +80,16 @@ export class RtuiButtonComponent {
     protected readonly resolvedAppearance: Signal<IRtuiButton.Appearance | undefined> = computed(
         () => this.appearance() ?? this.#buttonConfig?.appearance
     );
+    /** Native Material button appearance the pill renders with under `design: 'material'`. */
+    protected readonly materialAppearance: Signal<MatButtonAppearance> = computed(() => {
+        const appearanceMap: Record<IRtuiButton.Appearance, MatButtonAppearance> = {
+            solid: 'filled',
+            outline: 'outlined',
+            light: 'tonal',
+            text: 'text',
+        };
+        return appearanceMap[this.resolvedAppearance() ?? 'solid'];
+    });
     protected readonly resolvedIconSize: Signal<RtuiIconSizeType> = computed(() => {
         const iconSize: RtuiIconSizeType | undefined = this.iconSize();
 

--- a/projects/ui-kit/src/lib/ui-kit/config/rt-ui-config.ts
+++ b/projects/ui-kit/src/lib/ui-kit/config/rt-ui-config.ts
@@ -6,8 +6,9 @@ import type { RtThemeType } from '../theme/rtui-theme.types';
 /**
  * Design system a control renders with:
  * - `'custom'` — the rt-tools look (design tokens, pill shapes). The default.
- * - `'material'` — the classic Material (M3) look, for apps that have not migrated
- *   their visual language yet or need to match surrounding Material controls.
+ * - `'material'` — the control renders a NATIVE Angular Material component
+ *   (e.g. the button pill becomes a real `matButton`), for apps that have not
+ *   migrated their visual language yet or need to match surrounding Material controls.
  */
 export type RtUiDesign = 'material' | 'custom';
 


### PR DESCRIPTION
## Summary

Under `design: 'material'` the `rtui-button` pill now renders a NATIVE Angular Material button (`matButton`) instead of emulating the M3 look with SCSS. The Material theme fully owns the button's look, so it always matches surrounding Material controls.

## Changes

- Template: the pill branches on the resolved design — material renders `<button [matButton]="...">`, custom keeps the existing rt-styled button.
- Appearance mapping: `solid` → `filled` (default), `outline` → `outlined`, `light` → `tonal`, `text` → `text`.
- `variant: 'danger'` re-points the button's own theme tokens (`--mat-button-*`) at the M3 error role; other variants keep theme primary.
- Removed the SCSS M3-emulation block shipped in 0.0.24 — no longer needed.
- Specs updated: material assertions target the native `MatButton` and the appearance mapping (24 tests green).
- Docs: `rt-ui-config-migration.md` + `RtUiDesign` JSDoc updated.

## Notes

- `size`/`radius` remain custom-design knobs — under material the theme owns metrics.
- `type: 'icon' | 'fab'` keep the custom look for now; extending the native render to them is a follow-up.