### PR TITLE
fix(rt:ui-kit): keep projected button content in the material design branch

### DIFF
--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.html
@@ -1,3 +1,9 @@
+<!-- Projected content is declared once and outlet-rendered per design branch: duplicating
+     <ng-content /> across @if branches assigns the projected nodes to the first slot only. -->
+<ng-template #projectedContent>
+    <ng-content />
+</ng-template>
+
 @switch (type()) {
     @case ('pill') {
         @if (resolvedDesign() === 'material') {
@@ -18,7 +24,7 @@
                     @if (text()) {
                         <span>{{ text() }}</span>
                     }
-                    <ng-content />
+                    <ng-container [ngTemplateOutlet]="projectedContent" />
                     @if (icon() && iconPosition() === 'end') {
                         <rtui-icon matButtonIcon iconPositionEnd [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
                     }
@@ -42,7 +48,7 @@
                     @if (text()) {
                         <span rtElem="text">{{ text() }}</span>
                     }
-                    <ng-content />
+                    <ng-container [ngTemplateOutlet]="projectedContent" />
                     @if (icon() && iconPosition() === 'end') {
                         <rtui-icon rtElem="icon" [glyph]="icon()" [size]="resolvedIconSize()" [outlined]="outlined()" />
                     }

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts
@@ -1,9 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButton } from '@angular/material/button';
 import { By } from '@angular/platform-browser';
 
 import { IRtUiConfig, RT_UI_CONFIG } from '../../config';
 import { RtuiButtonComponent } from './rtui-button.component';
+
+@Component({
+    template: '<rtui-button type="pill">Projected label</rtui-button>',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RtuiButtonComponent],
+})
+class ProjectionHostComponent {}
 
 describe('RtuiButtonComponent', () => {
     function setup(config?: IRtUiConfig.Config): ComponentFixture<RtuiButtonComponent> {
@@ -87,6 +95,21 @@ describe('RtuiButtonComponent', () => {
 
         expect(matButton(fixture)).toBeUndefined();
         expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
+    });
+
+    it('renders projected content in both the custom and the material design branches', () => {
+        for (const design of ['custom', 'material'] as const) {
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                imports: [ProjectionHostComponent],
+                providers: [{ provide: RT_UI_CONFIG, useValue: { global: { design } } }],
+            });
+            const fixture: ComponentFixture<ProjectionHostComponent> = TestBed.createComponent(ProjectionHostComponent);
+            fixture.detectChanges();
+
+            const button: HTMLButtonElement = (fixture.nativeElement as HTMLElement).querySelector('button')!;
+            expect(button.textContent).toContain('Projected label');
+        }
     });
 
     it('lets explicit size/radius inputs override the config defaults', () => {

--- a/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
+++ b/projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts
@@ -1,4 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
+import { NgTemplateOutlet } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -38,6 +39,9 @@ export namespace IRtuiButton {
     styleUrl: './rtui-button.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
+        // angular
+        NgTemplateOutlet,
+
         // rt-tools
         BlockDirective,
         ElemDirective,


### PR DESCRIPTION
## Summary

0.0.25 regression: under `design: 'material'` the `rtui-button` pill rendered projected content (`<ng-content>`) as EMPTY — every button label passed as content disappeared. Angular assigns projected nodes to the first declared `<ng-content>` slot only, so duplicating the slot across the `@if/@else` design branches starved the material branch.

## Fix

- Declare `<ng-content />` once inside `<ng-template #projectedContent>` and render it in each branch via `ngTemplateOutlet` — the canonical pattern for conditional projection.
- Regression spec: a host component projects a label; the test asserts it renders in BOTH design branches (25 tests green).