### PR TITLE
chore: check in the agent skills and the hooks that enforce them

### DIFF
--- a/.claude/hooks/browser-device-id.sh
+++ b/.claude/hooks/browser-device-id.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Shared helper: prints RT_TOOLS_BROWSER_DEVICE_ID from the project's .env, or nothing.
+#
+# .env is gitignored and per-developer, so the browser guards configure themselves from it.
+# An unset/empty value means "not configured" and every guard must then allow the action —
+# a shared hook must never block a teammate who has not set this up.
+
+env_file="${CLAUDE_PROJECT_DIR:-.}/.env"
+[ -r "$env_file" ] || exit 0
+
+sed -n 's/^[[:space:]]*RT_TOOLS_BROWSER_DEVICE_ID[[:space:]]*=[[:space:]]*//p' "$env_file" \
+    | head -n 1 \
+    | sed -e 's/^"//' -e "s/^'//" -e 's/"[[:space:]]*$//' -e "s/'[[:space:]]*$//" -e 's/[[:space:]]*$//'

--- a/.claude/hooks/browser-guard-device-id.sh
+++ b/.claude/hooks/browser-guard-device-id.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse guard for mcp__claude-in-chrome__select_browser.
+#
+# Rejects any deviceId other than the pinned profile. Picking another one wastes a round trip
+# and lands on a browser without this project's sessions.
+#
+# On a successful match it stamps a per-session marker. browser-guard-require-select.sh reads
+# that marker's AGE, so the stamp is what makes later browser work legal.
+#
+# FAIL-OPEN when RT_TOOLS_BROWSER_DEVICE_ID is unset (see browser-guard-no-listing.sh).
+
+input="$(cat 2>/dev/null)"
+
+device_id="$("${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/browser-device-id.sh" 2>/dev/null)"
+[ -z "$device_id" ] && exit 0
+
+requested="$(printf '%s' "$input" | jq -r '.tool_input.deviceId // empty' 2>/dev/null)"
+
+if [ "$requested" = "$device_id" ]; then
+    sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
+    marker_dir="${TMPDIR:-/tmp}/claude-browser-guard"
+    mkdir -p "$marker_dir" 2>/dev/null && : >"$marker_dir/rt-tools-${sid}" 2>/dev/null
+    exit 0
+fi
+
+echo "deviceId '${requested}' is not the pinned Chrome profile. Use ${device_id} — the only profile set up for this project." >&2
+exit 2

--- a/.claude/hooks/browser-guard-no-asking.sh
+++ b/.claude/hooks/browser-guard-no-asking.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PreToolUse guard for AskUserQuestion.
+#
+# The browser choice is already made and pinned in .env — asking again is pure noise, and the
+# answer could only ever be the pinned profile. Only questions actually about picking a browser
+# are blocked; every other question passes untouched.
+#
+# FAIL-OPEN when RT_TOOLS_BROWSER_DEVICE_ID is unset.
+
+input="$(cat 2>/dev/null)"
+
+device_id="$("${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/browser-device-id.sh" 2>/dev/null)"
+[ -z "$device_id" ] && exit 0
+
+questions="$(printf '%s' "$input" | jq -r '[.tool_input.questions[]? | .question, .header, (.options[]?.label)] | join(" ")' 2>/dev/null)"
+[ -z "$questions" ] && exit 0
+
+printf '%s' "$questions" | grep -qiE 'browser|deviceid|device id|браузер' || exit 0
+
+echo "Do not ask which browser to use — it is pinned in .env. Call select_browser with deviceId ${device_id} (pinned Chrome profile)." >&2
+exit 2

--- a/.claude/hooks/browser-guard-no-listing.sh
+++ b/.claude/hooks/browser-guard-no-listing.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PreToolUse guard for mcp__claude-in-chrome__(list_connected_browsers|switch_browser).
+#
+# One pinned Chrome profile holds this project's sessions. Listing or switching browsers
+# returns generic, unstable display names ("Browser 1..6") that identify nothing, and picking
+# from them lands on a profile that is not logged in — so the only supported path is
+# select_browser with the pinned deviceId.
+#
+# FAIL-OPEN when RT_TOOLS_BROWSER_DEVICE_ID is unset: this hook is shared and must not
+# block anyone who has not configured a browser.
+
+cat >/dev/null 2>&1
+
+device_id="$("${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/browser-device-id.sh" 2>/dev/null)"
+[ -z "$device_id" ] && exit 0
+
+echo "Do not list or switch browsers. Use select_browser with deviceId ${device_id} — the pinned Chrome profile, the only profile set up for this project." >&2
+exit 2

--- a/.claude/hooks/browser-guard-no-other-drivers.sh
+++ b/.claude/hooks/browser-guard-no-other-drivers.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PreToolUse guard for every OTHER way to reach a browser.
+#
+# The pin is only worth something if claude-in-chrome is the ONLY door. These are the doors that
+# bypass it entirely — none of them consult the pinned deviceId:
+#   - mcp__playwright__*        a second driver, on a profile that is NOT logged in
+#   - mcp__chrome-devtools__*   a third driver, same problem
+#   - Bash: open <url>, open -a "Google Chrome", osascript telling Chrome to do things,
+#     chrome-cli, a raw chrome/chromium binary, playwright open|codegen|screenshot|cr
+#
+# Writing Playwright E2E *scripts* stays allowed: `playwright test` runs a spec, it does not
+# hand the agent an interactive browser. Only the driving verbs are denied.
+#
+# FAIL-OPEN when RT_TOOLS_BROWSER_DEVICE_ID is unset.
+
+input="$(cat 2>/dev/null)"
+
+device_id="$("${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/browser-device-id.sh" 2>/dev/null)"
+[ -z "$device_id" ] && exit 0
+
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)"
+
+deny() {
+    echo "$1 Use claude-in-chrome instead: select_browser with deviceId ${device_id} — the pinned Chrome profile — then drive it with mcp__claude-in-chrome__* tools." >&2
+    exit 2
+}
+
+case "$tool" in
+    mcp__playwright__*)
+        deny "Playwright MCP is not a browser driver in this project — its profile is not logged in." ;;
+    mcp__chrome-devtools__*)
+        deny "Chrome DevTools MCP is not a browser driver in this project — it does not honour the pinned profile." ;;
+esac
+
+[ "$tool" = "Bash" ] || exit 0
+
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -z "$cmd" ] && exit 0
+
+# `playwright test` (and its runner aliases) are the legitimate E2E path — never block them.
+case "$cmd" in
+    *playwright\ open*|*playwright\ codegen*|*playwright\ screenshot*|*playwright\ cr*)
+        deny "Driving a browser through the Playwright CLI bypasses the pinned profile." ;;
+esac
+
+case "$cmd" in
+    *open\ http*|*open\ -a\ *Chrome*|*open\ -a\ *chrome*)
+        deny "Opening a URL with \`open\` launches the default browser, not the pinned profile." ;;
+    *osascript*Chrome*|*osascript*chrome*)
+        deny "Driving Chrome via osascript bypasses the pinned profile." ;;
+    *chrome-cli*)
+        deny "chrome-cli bypasses the pinned profile." ;;
+esac
+
+# A Chrome/Chromium BINARY, and only in command position.
+#
+# A bare "*chromium *" glob is NOT usable here: it also matches `--project=chromium`, which is
+# the mandatory flag on every legitimate Playwright E2E run — that glob denied the e2e suite
+# itself the moment it shipped. So anchor on a command boundary and require an executable-looking
+# token, never a flag value.
+printf '%s' "$cmd" | grep -qE '(^|[;&|(]|[[:space:]]&&|[[:space:]]\|\|)[[:space:]]*(/[^[:space:]]*/)?(google-chrome|chromium)([[:space:]]|$)' \
+    && deny "Launching a Chrome binary directly bypasses the pinned profile."
+
+printf '%s' "$cmd" | grep -qF 'Google Chrome.app/Contents/MacOS' \
+    && deny "Launching the Chrome binary directly bypasses the pinned profile."
+
+exit 0

--- a/.claude/hooks/browser-guard-require-select.sh
+++ b/.claude/hooks/browser-guard-require-select.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PreToolUse guard for every other mcp__claude-in-chrome__* tool (tabs_context, navigate,
+# computer, read_page, …).
+#
+# WHY THIS EXISTS — the failure it is built from:
+# The extension acts on whatever browser it currently considers active, and that choice DRIFTS.
+# A select_browser early in a session does NOT hold: after a long stretch of non-browser work
+# the next tabs_context_mcp opened a tab in a DIFFERENT profile, silently. Guarding only
+# select_browser cannot catch this, because select_browser is never called at that point — the
+# id it was given was correct, and the drift happened afterwards.
+#
+# So this gate is about FRESHNESS, not about "was select ever called":
+#   - browser-guard-device-id.sh stamps a marker on every accepted select_browser;
+#   - every browser tool that passes here RE-STAMPS it, so an active burst keeps flowing;
+#   - once the marker goes older than the window, the next browser tool is denied and must
+#     re-select. A pause is exactly when drift happens, so a pause is what re-arms the gate.
+#
+# select_browser is one cheap idempotent call, so re-selecting costs far less than landing in
+# the wrong browser.
+#
+# Window: RT_TOOLS_BROWSER_DEVICE_ID_TTL seconds from .env, default 300.
+# list/switch/select have their own guards and are skipped here.
+#
+# FAIL-OPEN when RT_TOOLS_BROWSER_DEVICE_ID is unset.
+
+input="$(cat 2>/dev/null)"
+
+device_id="$("${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/browser-device-id.sh" 2>/dev/null)"
+[ -z "$device_id" ] && exit 0
+
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)"
+case "$tool" in
+    *list_connected_browsers|*switch_browser|*select_browser) exit 0 ;;
+esac
+
+ttl="$(sed -n 's/^[[:space:]]*RT_TOOLS_BROWSER_DEVICE_ID_TTL[[:space:]]*=[[:space:]]*//p' "${CLAUDE_PROJECT_DIR:-.}/.env" 2>/dev/null \
+    | head -n 1 | tr -d '"'"'"' \r')"
+case "$ttl" in
+    ''|*[!0-9]*) ttl=300 ;;
+esac
+
+sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
+marker="${TMPDIR:-/tmp}/claude-browser-guard/rt-tools-${sid}"
+
+if [ ! -f "$marker" ]; then
+    echo "No browser selected in this session. Call select_browser with deviceId ${device_id} — the pinned Chrome profile — before any other browser tool." >&2
+    exit 2
+fi
+
+now="$(date +%s)"
+stamped="$(stat -f %m "$marker" 2>/dev/null || stat -c %Y "$marker" 2>/dev/null || echo 0)"
+age=$(( now - stamped ))
+
+if [ "$age" -gt "$ttl" ]; then
+    rm -f "$marker" 2>/dev/null
+    echo "Last select_browser was ${age}s ago (limit ${ttl}s) — the extension's active browser drifts across gaps like this, so it may no longer be the pinned Chrome profile. Call select_browser with deviceId ${device_id} again, then retry." >&2
+    exit 2
+fi
+
+: >"$marker" 2>/dev/null
+exit 0

--- a/.claude/hooks/skill-gate-rearm.sh
+++ b/.claude/hooks/skill-gate-rearm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SessionStart(compact|clear) hook — re-arms the skill gate.
+#
+# The gate records a loaded skill per session_id and then passes that domain silently for the
+# rest of the session. Compaction and /clear wipe the skill's CONTENT out of context but keep
+# the SAME session_id, so without this the gate would keep passing while the agent works from
+# a summary instead of the actual skill.
+#
+# Dropping the record forces every domain to re-load its skill after a compaction.
+#
+# FAIL-OPEN: any error exits 0. This hook only deletes a temp file; it never blocks.
+
+input="$(cat 2>/dev/null)"
+[ -z "$input" ] && exit 0
+
+sid="$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)"
+[ -z "$sid" ] && exit 0
+
+rm -f "${TMPDIR:-/tmp}/claude-skill-gate/${sid}.loaded" 2>/dev/null
+
+exit 0

--- a/.claude/hooks/skill-gate.sh
+++ b/.claude/hooks/skill-gate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# PreToolUse gate for Edit|Write|MultiEdit and Bash(git commit/push).
+# Blocks the action ONCE per (session, domain) until the matching skill has been loaded this
+# session (recorded by skill-loaded.sh). After the skill is loaded the same domain passes
+# silently for the rest of the session — so there is no repetition and negligible token cost.
+#
+# FAIL-OPEN: on any error or unmapped path the action is ALLOWED (exit 0). A buggy gate must
+# never wedge editing.
+
+input="$(cat 2>/dev/null)"
+[ -z "$input" ] && exit 0
+
+sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)"
+
+req=""
+target=""
+case "$tool" in
+    Edit|Write|MultiEdit)
+        target="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+        [ -z "$target" ] && exit 0
+        # Most specific first — the first match wins. A story/spec is never a component file,
+        # so both must be tested before *.component.ts; the barrels must be tested before the
+        # *.ts catch-all.
+        case "$target" in
+            */.claude/*)                        exit 0 ;;
+            *.stories.ts)                       req="rt-tools-storybook" ;;
+            */stories/*.ts|*/strories/*.ts)     req="rt-tools-storybook" ;;
+            *.spec.ts)                          req="rt-tools-testing" ;;
+            *.component.ts|*.component.html)    req="rt-tools-component" ;;
+            *.scss)                             req="rt-tools-styling" ;;
+            */public-api.ts|*/index.ts)         req="rt-tools-public-api" ;;
+            *.ts)                               req="rt-tools-typescript" ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    Bash)
+        target="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+        case "$target" in
+            *git\ commit*|*git\ push*|*gh\ pr\ create*) req="rt-tools-ship-pr" ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+
+[ -z "$req" ] && exit 0
+
+# Accept both the bare skill name and a directory-scoped one ("<dir>:<name>").
+loaded="${TMPDIR:-/tmp}/claude-skill-gate/${sid}.loaded"
+if [ -f "$loaded" ] && grep -qE "^([^:]*:)?$(printf '%s' "$req" | sed 's/[][\.*^$/]/\\&/g')$" "$loaded" 2>/dev/null; then
+    exit 0
+fi
+
+reason="BLOCKED by skill-gate: load the '${req}' skill via the Skill tool BEFORE this action, then retry. This fires once per session for this domain."
+jq -n --arg r "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}' 2>/dev/null \
+    || printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Load the %s skill first, then retry."}}\n' "$req"
+
+exit 0

--- a/.claude/hooks/skill-loaded.sh
+++ b/.claude/hooks/skill-loaded.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# PostToolUse hook on the `Skill` tool.
+# Records which skill was loaded, per session, so the edit gate can verify it.
+# Always exits 0 and never blocks — this hook only observes.
+
+input="$(cat 2>/dev/null)"
+[ -z "$input" ] && exit 0
+
+sid="$(printf '%s' "$input" | jq -r '.session_id // "nosession"' 2>/dev/null)"
+skill="$(printf '%s' "$input" | jq -r '.tool_input.skill // empty' 2>/dev/null)"
+[ -z "$skill" ] && exit 0
+
+dir="${TMPDIR:-/tmp}/claude-skill-gate"
+mkdir -p "$dir" 2>/dev/null || exit 0
+printf '%s\n' "$skill" >> "$dir/${sid}.loaded" 2>/dev/null
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,92 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/skill-loaded.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Skill"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/browser-guard-no-listing.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__claude-in-chrome__(list_connected_browsers|switch_browser)"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/browser-guard-device-id.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__claude-in-chrome__select_browser"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/browser-guard-require-select.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__claude-in-chrome__.*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/browser-guard-no-asking.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "AskUserQuestion"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/skill-gate.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit|Bash"
+      },
+      {
+        "matcher": "mcp__playwright__.*|mcp__chrome-devtools__.*|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/browser-guard-no-other-drivers.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/skill-gate-rearm.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "compact|clear"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"AUTOMATED SKILLS REMINDER: Before editing any file, committing, or opening a PR, FIRST identify which .claude/skills apply and invoke them via the Skill tool — proactively, not after being reminded. Frequent ones: rt-tools-component (*.component.ts, rtui- selectors, signal-only API), rt-tools-styling (*.scss and the --rt-* token tiers), rt-tools-testing (*.spec.ts, Jest + zoneless TestBed), rt-tools-storybook (*.stories.ts and the Test*Component wrapper convention), rt-tools-public-api (barrels, entry points, peer ranges, breaking changes), rt-tools-typescript (any other .ts), rt-tools-board (cross-repo coordination), rt-tools-ship-pr (commits, PRs, publishing).\"}}'",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/rt-tools-board/scripts/board.sh
+++ b/.claude/skills/rt-tools-board/scripts/board.sh
@@ -19,6 +19,9 @@ set -euo pipefail
 BOARD_TITLE="${RT_BOARD_TITLE:-Rt-tools}"
 export BOARD_TITLE
 GH="command gh"
+# `gh project item-list` defaults to 30 items. The board is past that, so a newly added task
+# falls outside the page and reads as "not on board" — pass an explicit page size everywhere.
+ITEM_LIMIT="${RT_BOARD_ITEM_LIMIT:-500}"
 PY="command python3"
 
 owner() { $GH repo view --json owner -q .owner.login; }
@@ -60,7 +63,7 @@ for f in d['fields']:
 cmd_list() {
     local o num pid; o="$(owner)"
     read -r num pid < <(resolve_project)
-    $GH project item-list "$num" --owner "$o" --format json | $PY -c "
+    $GH project item-list "$num" --owner "$o" --limit "$ITEM_LIMIT" --format json | $PY -c "
 import json,sys
 d=json.load(sys.stdin)
 for it in d['items']:
@@ -100,7 +103,7 @@ print(field["id"], opts[0]["id"])
 ')
 
     local itemId
-    itemId="$($GH project item-list "$num" --owner "$o" --format json | TARGET="$target" $PY -c '
+    itemId="$($GH project item-list "$num" --owner "$o" --limit "$ITEM_LIMIT" --format json | TARGET="$target" $PY -c '
 import json, sys, os
 d = json.load(sys.stdin)
 t = str(os.environ["TARGET"])

--- a/.claude/skills/rt-tools-component/SKILL.md
+++ b/.claude/skills/rt-tools-component/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: rt-tools-component
+description: Author or edit an Angular component in this kit — rtui- selector, signal-only API (input/output/viewChild), OnPush, grouped imports, BEM template directives, RT_UI_CONFIG defaults. Use when creating a new component, editing any *.component.ts / *.component.html, adding an input/output, or wiring a component into the kit's config and theming.
+---
+
+# Component authoring
+
+Every shipped component lives in `projects/ui-kit/src/lib/ui-kit/<feature>/` as a
+co-located triple `rtui-<name>.component.{ts,html,scss}`, exported through the
+feature's `public-api.ts`.
+
+Reference implementation: `projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.ts`.
+
+## Golden rule
+
+Signals only. There are **zero** `@Output` and **zero** `@ViewChild` in
+`projects/`; the 6 remaining `@Input()`s live in the BEM directives
+(`projects/core/src/lib/bem/block.directive.ts`, `elem.directive.ts`) and one
+story wrapper. Do not add new ones.
+
+## Decorator shape
+
+```typescript
+@Component({
+    selector: 'rtui-button',
+    templateUrl: './rtui-button.component.html',
+    styleUrl: './rtui-button.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [
+        // angular
+        NgTemplateOutlet,
+
+        // rt-tools
+        BlockDirective,
+        ElemDirective,
+        ModDirective,
+
+        // components
+        RtuiIconComponent,
+
+        // material
+        MatButton,
+        MatRipple,
+    ],
+})
+```
+
+- `selector` is `rtui-<name>` (the Nx `prefix` for the library is `rt`).
+- `styleUrl` singular, never `styleUrls`.
+- `OnPush` on every component. `@angular-eslint/prefer-on-push-component-change-detection`
+  is only a `warn` because 3 legacy components predate it — new code has no excuse.
+- `imports` are grouped with the `// angular` / `// rt-tools` / `// components` /
+  `// directives` / `// material` comments.
+- Cross-package imports go through `@rt-tools/core|store|utils`, never relative paths.
+
+## Class members
+
+Explicit types on **every** field — `@typescript-eslint/typedef` and
+`explicit-member-accessibility` are `error`:
+
+```typescript
+readonly #config: IRtUiConfig.Config = inject(RT_UI_CONFIG);
+
+protected readonly resolvedSize: Signal<IRtuiButton.Size> = computed(() => this.size() ?? this.#buttonConfig?.size ?? 'md');
+
+public readonly type: InputSignal<IRtuiButton.Type> = input<IRtuiButton.Type>('icon');
+public readonly disabled: InputSignalWithTransform<boolean, BooleanInput> = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+});
+public readonly clicked: OutputEmitterRef<void> = output<void>();
+```
+
+- Order: `#` private fields → `protected` → `public` (inputs/outputs) →
+  constructor → public → protected → private methods (`member-ordering`).
+- `inject()` over constructor DI (60 `inject(` calls vs 1 component constructor).
+- `#` for privates (167 uses) — the `private` keyword survives in ~10 legacy spots only.
+- Boolean inputs take `transform: booleanAttribute`; string inputs take
+  `transform: transformStringInput` from `@rt-tools/utils`.
+- Group a component's public type unions in a namespace beside the class
+  (`export namespace IRtuiButton { export type Size = 'xs' | 'sm' | 'md' | 'lg'; }`) —
+  `@typescript-eslint/no-namespace` is off deliberately.
+
+## Config-driven defaults
+
+Components with themable defaults resolve them in this order — **instance input →
+`components.<name>` → `global` → library default** — via `RT_UI_CONFIG`
+(`projects/ui-kit/src/lib/ui-kit/config/`):
+
+```typescript
+protected readonly resolvedDesign: Signal<RtUiDesign> = computed(
+    () => this.design() ?? this.#buttonConfig?.design ?? this.#config.global?.design ?? 'custom'
+);
+```
+
+Never read config in a field initializer that a consumer could override — resolve
+it in a `computed()`.
+
+## Templates
+
+- BEM via directives only: `rtBlock` / `rtElem` / `[rtMod]` from `@rt-tools/core`.
+  `rt/require-bem-directives` (warn) rejects `class="…"`, `[class.x]`, `[ngClass]`;
+  the only escape hatch in `[class]` is `… | concatClasses`, and raw classes are
+  tolerated today solely for the Material bridge (`class="rtui-button-material"`).
+- **Using `rtMod` obliges you to put `ModDirective` in `imports`** —
+  `rt/require-mod-directive-import` is `error`. Without it the directive is
+  tree-shaken and modifiers silently vanish in prod (13 components had this bug).
+- Build the modifier record in a `computed()` and bind it once:
+  `[rtMod]="modifiers()"` where `modifiers()` returns `{ 'size-md': true, loading: … }`.
+- Control flow is `@if` / `@for` / `@switch`. Template cyclomatic complexity max is 25.
+- **Never repeat `<ng-content />` across `@if` branches** — projected nodes bind to
+  the first slot only. Declare it once in an `<ng-template #projectedContent>` and
+  render it with `[ngTemplateOutlet]` per branch (see `rtui-button.component.html`).
+- Alias Material behaviour with `hostDirectives` instead of re-declaring inputs:
+
+    ```typescript
+    hostDirectives: [{ directive: MatTooltip, inputs: ['matTooltip: tooltip', 'matTooltipPosition: tooltipPosition'] }],
+    ```
+
+## Host class
+
+Current reality: components use a string-literal `host: { class: 'rtui-icon' }`
+(`icon`, `modal`, `aside`) or a bound state class
+(`'[class.rtui-button-full]': 'fullWidth()'`), and many declare no host class at
+all. `rt/require-host-bem-block` (which wants a local `const BEM_BLOCK`) is
+deliberately at `warn` pending a convention decision — match the neighbouring
+component, do not mass-migrate to silence the warning.
+
+## Before you finish
+
+```bash
+pnpm exec nx lint @rt-tools/ui-kit
+pnpm exec nx test @rt-tools/ui-kit --testFile=<spec>
+```
+
+New public component → wire its barrel (see the **rt-tools-public-api** skill),
+add a story (**rt-tools-storybook**), and style it with tier-3 tokens
+(**rt-tools-styling**).

--- a/.claude/skills/rt-tools-public-api/SKILL.md
+++ b/.claude/skills/rt-tools-public-api/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: rt-tools-public-api
+description: Keep the published surface of the four packages correct — the public-api.ts + index.ts barrel pair, the ui-kit root entry, tsconfig paths, package peer ranges and what counts as a breaking change. Use when editing any public-api.ts or index.ts, adding/removing/renaming an export, creating a new feature folder, or changing a package's dependencies.
+---
+
+# Public API discipline
+
+Four published packages, each with its own version and entry point:
+
+| package            | entry                               | consumed as        |
+| ------------------ | ----------------------------------- | ------------------ |
+| `@rt-tools/core`   | `projects/core/src/index.ts`        | `@rt-tools/core`   |
+| `@rt-tools/store`  | `projects/store/src/index.ts`       | `@rt-tools/store`  |
+| `@rt-tools/utils`  | `projects/utils/src/index.ts`       | `@rt-tools/utils`  |
+| `@rt-tools/ui-kit` | `projects/ui-kit/src/public-api.ts` | `@rt-tools/ui-kit` |
+
+These four paths are mirrored in `tsconfig.base.json` `paths` and, for ui-kit, in
+`projects/ui-kit/ng-package.json` (`lib.entryFile`). They must stay in sync.
+
+## Golden rule
+
+**A file that no barrel re-exports does not ship.** Every feature folder carries a
+`public-api.ts` listing its exports explicitly, plus a one-line `index.ts`:
+
+```typescript
+// projects/ui-kit/src/lib/ui-kit/buttons/public-api.ts
+export * from './unified-button/rtui-button.component';
+export * from './multi-button/rtui-multi-button.component';
+```
+
+```typescript
+// projects/ui-kit/src/lib/ui-kit/buttons/index.ts
+export * from './public-api';
+```
+
+The root entry re-exports the folder (which resolves via `index.ts`), grouped by
+comment:
+
+```typescript
+// projects/ui-kit/src/public-api.ts
+// ui-kit
+export * from './lib/ui-kit/buttons';
+export * from './lib/ui-kit/icon';
+```
+
+`core` / `store` / `utils` use the same shape one level up — `src/index.ts` groups
+by category (`// functions`, `// services`, `// tokens`, `// types`, `// bem`, …)
+and each category folder owns its `public-api.ts` + `index.ts` pair.
+
+## Adding a component or symbol
+
+1. Create it under `projects/<pkg>/src/lib/...`.
+2. Add an explicit line to the nearest `public-api.ts` (never `export * from './some-folder'`
+   pointing at a bare directory of files — list the modules).
+3. New folder → also create `index.ts` with `export * from './public-api';`.
+4. New top-level feature → register it in `projects/ui-kit/src/public-api.ts`
+   (or the package's `src/index.ts`).
+5. Build the package and confirm the symbol is in the `.d.ts`:
+   `pnpm run build:ui-kit` → `dist/ui-kit/`.
+
+**Do not export story scaffolding.** `Test*Component` wrappers under `stories/`
+are demo-only and stay out of every barrel.
+
+## Dependencies between packages
+
+- ui-kit depends on the other three: `implicitDependencies` in
+  `projects/ui-kit/project.json`, `allowedNonPeerDependencies` in
+  `ng-package.json`, and both `dependencies` **and** `peerDependencies` entries in
+  `projects/ui-kit/package.json`. Bumping `@rt-tools/core` means updating both
+  ranges there.
+- Angular/CDK/Material/rxjs/TypeScript are `peerDependencies` (`^22.0.0`, `^7.8.2`,
+  `^6.0.0`) — never promote one to a real dependency.
+- Every package is `"sideEffects": false`; keep barrels free of side-effectful
+  module-level code or tree-shaking silently breaks for consumers.
+- Import across packages by path alias (`@rt-tools/core`), never
+  `../../../core/src/...`. `@nx/enforce-module-boundaries` is `error`.
+
+## Breaking changes
+
+Removing or renaming an export, narrowing a type, or dropping a `--rt-*` public
+theming var is **breaking** for the published package. When it happens:
+
+- bump the version in `projects/<pkg>/package.json` and any dependent range;
+- record it in the `## [Unreleased]` block of `projects/<pkg>/CHANGELOG.md`
+  (released sections are conventional-commit generated — never rewrite them);
+- flag it in the PR body.
+
+See the **rt-tools-ship-pr** skill for the CHANGELOG/PR mechanics. Publishing is a
+`workflow_dispatch` GitHub Action per package (`.github/workflows/publish.yml`,
+`publish-core.yml`, `publish-store.yml`, `publish-utils.yml`) — not a local
+`npm publish`.
+
+## Verify
+
+```bash
+pnpm run build:all      # every package must build from its entry
+pnpm run check:affected # lint + test + build for touched packages
+```

--- a/.claude/skills/rt-tools-storybook/SKILL.md
+++ b/.claude/skills/rt-tools-storybook/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: rt-tools-storybook
+description: Add or edit a Storybook story for a kit component — the Test*Component wrapper convention, Meta/StoryObj typing, applicationConfig decorators and argTypes controls. Use when creating any *.stories.ts, adding a demo variant for a component, or wiring token/theming docs into Storybook.
+---
+
+# Storybook
+
+Storybook 10 with `@storybook/angular`. Config lives in
+`projects/ui-kit/.storybook/`; stories are discovered from
+`../src/**/*.stories.@(js|jsx|mjs|ts|tsx)` and docs from `../docs/**/*.mdx`.
+
+```bash
+pnpm run storybook          # nx run @rt-tools/ui-kit:storybook — port 6006
+pnpm run build-storybook    # dist/storybook/@rt-tools/ui-kit
+```
+
+## Golden rule
+
+**A story never targets the `rtui-*` component directly — it targets a
+`Test*Component` wrapper** that lives next to the story in `stories/component/`.
+Every story in the kit follows this (checkbox, toggle, modal, header, side-menu,
+snack-bar, info-badge, file-uploader, image-uploader, dynamic-selectors). The
+wrapper owns the plain mutable demo state that Storybook `args` can bind to,
+because the real component's API is `InputSignal`-based.
+
+```
+toggle/
+  rtui-toggle.component.ts
+  stories/
+    toggle.stories.ts
+    component/
+      test-toggle.component.{ts,html,scss}
+```
+
+## Story file shape
+
+```typescript
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+
+import { TOGGLE_SIZE_TYPE_ENUM } from '../toggle-size.type.enum';
+import { TestToggleComponent } from './component/test-toggle.component';
+
+export default {
+    title: 'Components/Toggle',
+    component: TestToggleComponent,
+    decorators: [
+        applicationConfig({
+            providers: [provideAnimations()],
+        }),
+    ],
+    argTypes: {
+        size: {
+            type: 'string',
+            options: [TOGGLE_SIZE_TYPE_ENUM.MD, TOGGLE_SIZE_TYPE_ENUM.SM, 'fat'],
+            control: { type: 'select' },
+        },
+    },
+} as Meta<TestToggleComponent>;
+
+type Story = StoryObj<TestToggleComponent>;
+
+export const Toggle: Story = {
+    args: {
+        value: true,
+        disabled: false,
+        size: TOGGLE_SIZE_TYPE_ENUM.MD,
+        label: 'Label Example',
+    },
+};
+```
+
+- `title` is `Components/<PascalName>`.
+- Default export is `as Meta<TestX>`; alias `type Story = StoryObj<TestX>` and type
+  every named export with it.
+- Providers go through `applicationConfig` in `decorators` — `provideAnimations()`
+  is the standard one. There is no global `preview.ts` provider for it.
+- One named export per variant (`Default`, `Mobile`, `InfoBadgeColors`, …),
+  differing only in `args`. Enumerate options with the component's own
+  `*_ENUM` const rather than string literals.
+
+## The wrapper component
+
+```typescript
+@Component({
+    selector: 'app-toggle',
+    templateUrl: './test-toggle.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [
+        // directives
+        BlockDirective,
+        ElemDirective,
+
+        // components
+        RtuiToggleComponent,
+        FormsModule,
+    ],
+})
+export class TestToggleComponent {
+    public value: boolean = true;
+    public size: ToggleSizeType = TOGGLE_SIZE_TYPE_ENUM.MD;
+}
+```
+
+- `app-` selector (demo scaffolding, not a shipped `rtui-` component).
+- Plain public fields — these are the Storybook control surface.
+- Wrapper styles are exempt from the design-token stylelint rule (the
+  `**/stories/**` ignore), so demo layout CSS is fine there.
+- The wrapper is **not** exported from any `public-api.ts` — it must never ship.
+
+## Gotchas
+
+- `.storybook` is excluded from ESLint (`eslint.config.cjs` ignores), and
+  `main.ts` carries a `/* eslint-disable */`. Do not rely on lint to catch
+  mistakes in that folder.
+- `projects/ui-kit/src/lib/ui-kit/dynamic-selectors/` uses a misspelled
+  `strories/` folder. It is matched by the `../src/**` glob and works; leave it
+  unless you are deliberately renaming it (both the stylelint ignore and any
+  tooling reference the typo).
+- Token/theming documentation is MDX in `projects/ui-kit/docs/` (`DesignTokens.mdx`,
+  `Theming.mdx`, `TokenColors.mdx`, …), not stories. Adding a token → update the
+  matching MDX page and `projects/ui-kit/src/styles/TOKENS.md`.
+- `console.log` in a wrapper needs an explicit `// eslint-disable-next-line no-console`
+  (`no-console` is `error` repo-wide).

--- a/.claude/skills/rt-tools-styling/SKILL.md
+++ b/.claude/skills/rt-tools-styling/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: rt-tools-styling
+description: Write or edit SCSS in this kit — BEM class shapes produced by rtBlock/rtElem/rtMod, the three-tier --rt-* design tokens, the per-component SCSS map that emits tier-3 vars, rem values, and the no-hardcoded-design-tokens stylelint rule. Use when touching any *.scss, adding a component style, recoloring something, or reaching for a hex value or a magic number.
+---
+
+# Styling
+
+Component styles are BEM, scoped to `:host`, and consume CSS custom properties.
+Nothing in `projects/ui-kit/src/lib/**` may hardcode a design value.
+
+Reference: `projects/ui-kit/src/lib/ui-kit/toggle/rtui-toggle.component.scss`.
+Token system docs: `projects/ui-kit/src/styles/TOKENS.md` (+ Storybook
+`projects/ui-kit/docs/*.mdx`). Read TOKENS.md before inventing a token name.
+
+## Golden rule
+
+`stylelint` blocks hardcoded values in `projects/ui-kit/src/lib/**/*.scss`:
+`color-no-hex: true` plus the workspace rule
+`rt-tools/no-hardcoded-design-tokens` (`tools/stylelint-rules/no-hardcoded-design-tokens.cjs`).
+Only `var(--rt-*)`, `var(--mat-*)`, `var(--mdc-*)` are accepted var prefixes;
+colors, magic numbers in spacing/radius/font-size/border-width, SCSS color
+functions and `$var` / `#{}` interpolation in token-aware properties are all
+rejected. `calc/min/max/clamp`, `color-mix`, `0` and universal keywords pass.
+Story/demo styles under `**/stories/**` (and the legacy `**/strories/**`) are
+exempt — they are scaffolding, not shipped CSS.
+
+## Token tiers
+
+```
+Tier 1  primitives   --rt-color-*                    styles/base/_tokens.scss
+Tier 2  semantic     --rt-{bg,text,icon,border}-*    styles/base/_tokens.scss (light-dark())
+Tier 3  component    --rt-<component>-<el>-<token>   per-component SCSS map
+```
+
+Light is the default; `.rt-dark` is the global switch, `data-rt-theme` scopes a
+nested context, `.rt-theme-auto` follows the OS (`RtThemeService` /
+`RtThemeDirective`). Semantic tokens are `var(--mat-sys-*, light-dark(…))`
+fallback chains for the Material hybrid.
+
+## Tier-3 pattern (how a component emits its vars)
+
+Declare a SCSS map of `element → (property: value)`, emit it through
+`mixins.generateCssVar`, then consume the vars in the rules:
+
+```scss
+@use '../../../styles/base/mixin' as mixins;
+
+$toggle: (
+    toggle-track: (
+        background-color: var(--rt-control-track),
+        border-radius: 2.5rem,
+    ),
+    label: (
+        color: var(--rt-text-base-secondary),
+        font-size: 0.875rem,
+    ),
+);
+
+:host {
+    @each $element, $elements in $toggle {
+        @each $style-token, $value in $elements {
+            #{mixins.generateCssVar('toggle', #{$element}, #{$style-token})}: #{$value};
+        }
+    }
+
+    .rtui-toggle-container__label {
+        color: var(--rt-toggle-label-color);
+        font-size: var(--rt-toggle-label-font-size);
+    }
+}
+```
+
+`generateCssVar('toggle', 'label', 'color')` → `--rt-toggle-label-color`
+(prefix from `$styles-prefix: 'rt'` in `styles/base/_variables.scss`).
+
+Emission scope decides override semantics (TOKENS.md): vars emitted at `:root`
+(global stylesheets, `ViewEncapsulation.None` components) are overridable from any
+ancestor; vars emitted at `:host` sit on the element and beat inherited values, so
+consumers need an element-targeted override. Prefer keeping a new themable var in
+the tier-3 map rather than adding a new public size hook — the public tier-3 API
+is only `--rt-<component>-*-{color,background-color,bg,shadow,indicator}` plus the
+documented size hooks listed in TOKENS.md.
+
+## Rules of thumb
+
+- **rem, not px.** Component values are authored in rem (`0.875rem`, `2.5rem`).
+  `mixins.rem(16)` converts against a 16px context if you have a px spec.
+  Breakpoint `$device-*` variables in `_variables.scss` are the px exception.
+- **BEM class shapes come from the directives**, not from hand-written strings:
+  `rtBlock="rtui-toggle"` → `.rtui-toggle`, `rtElem="label"` → `.rtui-toggle__label`,
+  `[rtMod]="{ sizeMd: true }"` → `.rtui-toggle--size--md`. Style those shapes;
+  `selector-class-pattern` is disabled because BEM, `.--state` modifiers and
+  `.mdc-*` internals all coexist.
+- **Scope to `:host`.** Use `:host(.rtui-button-full)` for host state classes.
+- **Media queries via mixins**: `@include mixins.media-breakpoint-down($device-sm)`.
+- **Global Material/CDK overrides go in `styles/components/_material-bridge.scss`**
+  (one file to review on a Material upgrade); component-scoped piercings stay with
+  their component. `::ng-deep` is allowed by stylelint (`ignorePseudoElements`).
+- Property order is enforced by `stylelint-config-idiomatic-order`; prettier runs
+  through `stylelint-prettier`.
+- `.c-button` (`styles/base/_button.scss`) is **deprecated** — `.rtui-btn`
+  (`_rtui_button.scss`) is the system. Migration map in TOKENS.md.
+
+## Verify
+
+```bash
+pnpm exec stylelint "projects/**/*.scss"
+pnpm run build:tokens   # regenerates dist/ui-kit/styles/tokens.css for non-sass consumers
+```
+
+Touching `styles/base/_tokens.scss` or `_color-scheme.scss` → run
+`projects/ui-kit/src/styles/color-scheme.spec.ts` (`pnpm exec nx test @rt-tools/ui-kit`).

--- a/.claude/skills/rt-tools-testing/SKILL.md
+++ b/.claude/skills/rt-tools-testing/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: rt-tools-testing
+description: Write or run unit tests in this kit — Jest (not Vitest) with jest-preset-angular, a zoneless TestBed, setInput-driven fixtures and DOM-class assertions. Use when creating or editing any *.spec.ts, adding coverage for a component/service/pipe, or running a single test file.
+---
+
+# Testing
+
+Jest + `jest-preset-angular`, one project per package, specs co-located with the
+source as `*.spec.ts`.
+
+Reference specs:
+
+- component — `projects/ui-kit/src/lib/ui-kit/buttons/unified-button/rtui-button.component.spec.ts`
+- service/store — `projects/store/src/lib/base-store.service.spec.ts`
+- pure function/pipe — `projects/utils/src/lib/functions/sorters.spec.ts`
+
+## Golden rule
+
+The TestBed is **zoneless**. `projects/ui-kit/src/test-setup.ts` runs
+`setupZonelessTestEnv({ errorOnUnknownElements: true, errorOnUnknownProperties: true })`
+— a missing import in the component under test fails the spec instead of silently
+rendering nothing. Drive change detection explicitly with `fixture.detectChanges()`.
+
+## Commands
+
+```bash
+pnpm test                                                        # nx run-many -t test
+pnpm exec nx test @rt-tools/ui-kit                               # one package
+pnpm exec nx test @rt-tools/ui-kit --testFile=<relative-path>    # one file
+```
+
+`passWithNoTests` is on, so an empty run is green — never take a passing target as
+proof your spec ran; check the reported test count.
+
+## Component spec shape
+
+A local `setup()` helper that configures the TestBed, seeds inputs via
+`componentRef.setInput`, and returns the fixture; small query helpers on top:
+
+```typescript
+function setup(config?: IRtUiConfig.Config): ComponentFixture<RtuiButtonComponent> {
+    TestBed.configureTestingModule({
+        imports: [RtuiButtonComponent],
+        providers: [{ provide: RT_UI_CONFIG, useValue: config ?? {} }],
+    });
+
+    const fixture: ComponentFixture<RtuiButtonComponent> = TestBed.createComponent(RtuiButtonComponent);
+    fixture.componentRef.setInput('type', 'pill');
+    fixture.detectChanges();
+
+    return fixture;
+}
+
+it('defaults to the custom design, md size and full radius without any config', () => {
+    const fixture: ComponentFixture<RtuiButtonComponent> = setup();
+
+    expect(buttonClasses(fixture).contains('rtui-button--design-custom')).toBe(true);
+});
+```
+
+- Standalone components go straight into `imports` — no NgModules.
+- **Inputs are set with `componentRef.setInput(...)`**, never by assigning to the
+  instance field (they are `InputSignal`s).
+- Assert on the rendered BEM classes (`rtui-button--size-md`) and on real
+  directive instances via `fixture.debugElement.query(By.directive(MatButton))` —
+  that is how this kit proves modifiers and the Material bridge actually apply.
+- Content projection needs a host wrapper component declared in the spec file:
+
+    ```typescript
+    @Component({
+        template: '<rtui-button type="pill">Projected label</rtui-button>',
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        imports: [RtuiButtonComponent],
+    })
+    class ProjectionHostComponent {}
+    ```
+
+- To re-provide a token per case, `TestBed.resetTestingModule()` then reconfigure
+  (see the design loop in `rtui-button.component.spec.ts`).
+- Config-driven components are worth testing across the whole resolution ladder:
+  instance input → `components.<name>` → `global` → library default.
+
+## Style inside specs
+
+The repo's TypeScript rules apply to specs too — explicit types on locals
+(`const fixture: ComponentFixture<X> = …`), explicit return types on helpers,
+single quotes. Only the custom `rt/*` workspace rules skip `*.spec.ts`.
+
+## Gotchas
+
+- **It is Jest, not Vitest** — `jest.fn()`, `jest.spyOn()`, `describe/it/expect`
+  from `@types/jest`. Do not import from `vitest`.
+- `@angular/cdk/*` and `@angular/material/*` are mapped to their `fesm2022` builds
+  via `moduleNameMapper` in `projects/ui-kit/jest.config.ts`; a new deep import
+  from a package shipped only as ESM may need a `transformIgnorePatterns` /
+  mapper entry there.
+- Coverage lands in `coverage/<displayName>` (e.g. `coverage/rt-ui-kit`).
+- CI runs `nx affected -t lint test build` against `origin/main`
+  (`.github/workflows/ci.yml`) — a spec that only passes locally blocks the PR.

--- a/.claude/skills/rt-tools-typescript/SKILL.md
+++ b/.claude/skills/rt-tools-typescript/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: rt-tools-typescript
+description: TypeScript conventions enforced across this repo — mandatory explicit types and member accessibility, member ordering, # private fields, the Source suffix for Subjects, and terminated subscriptions. Use when writing or editing any *.ts (service, directive, pipe, store, function, token) before running lint.
+---
+
+# TypeScript conventions
+
+Every rule below is enforced at `error` by `eslint.config.cjs` or the workspace
+plugin in `tools/lint-rules/`. Toolchain: TypeScript 6, Angular 22, `strict`
+
+- `noPropertyAccessFromIndexSignature`, target ES2022, `useDefineForClassFields: false`.
+
+## Golden rule
+
+Nothing is implicit. `@typescript-eslint/typedef` demands a type annotation on
+parameters, arrow parameters, property declarations, variable declarations,
+member variables and array destructuring;
+`@typescript-eslint/explicit-function-return-type` and
+`explicit-member-accessibility` (constructors: `no-public`) complete the set.
+
+```typescript
+readonly #devToolsManager: DevToolsManagerService | null = inject(DevToolsManagerService, { optional: true });
+
+public patchState(callbackFn: (state: STATE_TYPE) => STATE_TYPE, actionName?: string): void {
+    this.#store.update((currState: STATE_TYPE): STATE_TYPE => callbackFn(currState));
+}
+```
+
+Yes, this means annotating locals you would normally infer
+(`const fixture: ComponentFixture<X> = TestBed.createComponent(X);`).
+
+## Privacy and ordering
+
+- **`#` private fields**, not the `private` keyword — 167 uses vs ~10 legacy spots.
+- `@typescript-eslint/member-ordering` fixes the layout: private fields →
+  protected fields → public fields → signature → constructors → public methods →
+  static/abstract → protected methods → private methods.
+- `readonly` on anything not reassigned.
+
+## RxJS
+
+Two workspace rules, both `error`, both currently at 0 violations — keep it that way:
+
+- **`rt/require-source-suffix-for-subjects`** — a class field initialized with
+  `new Subject()` / `BehaviorSubject` / `ReplaySubject` / `AsyncSubject` must end in
+  `Source`. The writable source is `#refreshSource`; the public read-only
+  `asObservable()` view carries no suffix.
+- **`rt/require-take-until-destroyed`** — every `.subscribe()` must sit after a
+  `.pipe()` containing a terminating operator: `takeUntilDestroyed`, `takeUntil`,
+  `take`, `first`, `last`, `toPromise`, `firstValueFrom`, `lastValueFrom`. A
+  genuinely non-RxJS `.subscribe()` (e.g. the Redux DevTools handle) takes an
+  explicit disable comment — that is the only precedent for opting out.
+
+## State
+
+Signal stores extend `BaseStoreService` / `BaseAsyncStoreService`
+(`projects/store/src/lib/`): a `WritableSignal` behind `store.asReadonly()`, a
+`MessageBus`-backed `dispatch`/`onDispatch`, and `patchState(fn)`. Cleanup hangs
+off `inject(DestroyRef).onDestroy(...)`, not `ngOnDestroy`.
+
+## Naming and shape
+
+- Interfaces `I`-prefixed (`IAction`, `IRtUiConfig`, `IModsObject`); enum-like
+  consts as `*_ENUM` in `*.type.enum.ts` (`TOGGLE_SIZE_TYPE_ENUM`).
+- `export namespace` is the sanctioned way to group a feature's public types —
+  `@typescript-eslint/no-namespace` is off on purpose
+  (`IRtuiButton`, `IRtUiConfig`, `ITable`, `IModal`, `ISideMenu`, …).
+- Files: `*.component.ts`, `*.directive.ts`, `*.pipe.ts`, `*.service.ts`,
+  `*.interface.ts`, `*.types.ts`, `*.type.enum.ts`, `*.function.ts`, `*.spec.ts`.
+- Cross-package imports use `@rt-tools/core|store|utils` (mapped in
+  `tsconfig.base.json`), never relative paths across `projects/*`.
+
+## Style
+
+`no-console`, `no-debugger`, `no-var`, `no-bitwise`, `no-eval`, `prefer-const`,
+`semi`, single quotes — all `error`. Prettier: 140 columns, 4-space tabs, single
+quotes, `trailingComma: es5`, LF. Import order is
+`@angular/*` → `rxjs` → `ng*` → third-party → relative, separated by blank lines
+(`.prettierrc.json` `importOrder`).
+
+Comments and JSDoc **are** used here — short doc blocks on non-obvious public API
+and on the "why" of a workaround are the house style
+(`rtui-button.component.ts`, `tools/lint-rules/*`).
+
+## Verify
+
+```bash
+pnpm exec nx lint @rt-tools/<package>     # or: pnpm run lint
+pnpm run check:affected                   # lint + test + build for touched packages
+```
+
+`lint-staged` runs `eslint --fix` + `prettier` on commit via husky.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Chrome device id of YOUR logged-in browser profile for this project (claude-in-chrome).
+# Read by .claude/hooks/browser-*.sh, which keep the agent pinned to that one profile
+# instead of listing or guessing browsers. Copy it from the claude-in-chrome extension.
+# Leave empty to disable the guards.
+RT_TOOLS_BROWSER_DEVICE_ID=""

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ testem.log
 .DS_Store
 Thumbs.db
 
+# Local, per-developer env (see .env.example)
+.env
+
 # Angular
 .angular
 


### PR DESCRIPTION
## Summary

Two of the eight agent skills — `rt-tools-board` and `rt-tools-ship-pr` — were in the repository. The other six, and every hook that makes any of them actually fire, lived in a single working copy. For anyone else, the conventions those skills describe were enforced by review alone.

- **Six skills**: `rt-tools-component`, `rt-tools-styling`, `rt-tools-testing`, `rt-tools-storybook`, `rt-tools-public-api`, `rt-tools-typescript`.
- **The skill gate** — `skill-gate.sh` (PreToolUse on `Edit|Write|MultiEdit|Bash`) maps the file being edited to the skill that governs it and blocks **once per session per domain** until that skill is loaded. `skill-loaded.sh` records the load; `skill-gate-rearm.sh` drops the record on compaction and `/clear`, when the skill's *content* leaves the context but the session id does not — without it the gate would keep passing while the agent works from a summary.
- **The browser guards** — pin browser automation to one configured Chrome profile instead of listing or guessing which one to drive.
- **The prompt reminder** that names the skills up front, so the gate is a backstop rather than the first thing anyone meets.

## Fail-open, on purpose

Every hook exits 0 on any error, any unmapped path, and any missing configuration. A gate that wedges editing is worse than no gate. The browser guards read `RT_TOOLS_BROWSER_DEVICE_ID` from a gitignored `.env`; unset means "not configured" and every guard allows the action, so a teammate who has not set it up is never blocked. `.env.example` documents the variable and `.gitignore` gains `.env`.

The gate blocks at most once per domain per session, so the token cost is one refusal, not a running commentary. Paths under `.claude/` are exempt, and the match order is most-specific-first — a `*.stories.ts` or `*.spec.ts` is never treated as a component file, and the barrels are matched before the `*.ts` catch-all.

## One fix carried along

`board.sh` called `gh project item-list` without `--limit`, which returns 30 items. The board is past that, so a freshly added task fell outside the page and the script reported it as not on the board — reproduced while filing this very issue. Both call sites now pass an explicit page size, overridable with `RT_BOARD_ITEM_LIMIT`.

## Checked before committing

- No secrets: the only credential-shaped value is the browser device id, which is read from `.env` and is absent from every checked-in file.
- No absolute or machine-specific paths.
- Hooks are committed with the executable bit set.
- Nothing outside the agent configuration is included; the untracked task notes and `docs/adr/` in the working tree are left alone.

## Test plan

- [x] `skill-gate.sh` blocks and then passes — exercised repeatedly while writing this session's changes
- [x] `board.sh status` works again on a task added past the first 30 board items
- [ ] CI green (no project source changes, so `nx affected` has nothing to run)

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)