### PR TITLE
fix: stop Dependabot from opening npm version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,19 @@ version: 2
 
 updates:
     # npm: security patches only. Everything vulnerable here lives in the dev/build
-    # graph, so a single grouped PR per week is enough noise. Version updates are
-    # left out on purpose — the Angular/Nx versions are pinned deliberately.
+    # graph, so a single grouped PR per week is enough noise.
+    #
+    # `open-pull-requests-limit: 0` is what suppresses version updates — registering an
+    # ecosystem turns them on, and the `groups` block below only decides how security PRs
+    # are batched. The limit does not apply to security PRs, so those still come through.
+    # Version updates stay off on purpose: the Angular and Nx versions here are pinned by
+    # hand and a lone bump desyncs one package from the rest of its family.
     - package-ecosystem: npm
       directory: /
       schedule:
           interval: weekly
           day: monday
-      open-pull-requests-limit: 5
+      open-pull-requests-limit: 0
       commit-message:
           prefix: chore
           include: scope


### PR DESCRIPTION
## Summary

The Dependabot config added in #237 was meant to deliver security patches only. It did not — one minute after that PR merged, Dependabot opened six npm version-update PRs (#238–#243).

Registering a `package-ecosystem` turns version updates **on**. The `groups` block with `applies-to: security-updates` only decides how security PRs are batched; it switches nothing off. `open-pull-requests-limit: 0` is the documented way to keep an ecosystem registered for advisories while suppressing version updates — the limit does not apply to security PRs.

## Changes

- `.github/dependabot.yml` — npm ecosystem: `open-pull-requests-limit: 5` → `0`, with a comment explaining which knob does the suppressing so the next reader doesn't reach for the `groups` block again.
- GitHub Actions keeps its monthly version updates unchanged: those bumps are small, self-contained, and nothing pins them by hand.

## Why version updates stay off

The Angular and Nx versions in this repo are pinned to exact versions across the whole family (`@angular/*` at 22.0.5, `@nx/*` at 23.1.0-rc.0). A Dependabot PR that lifts one member out of the set — as #243 does with `@angular-devkit/core` → 22.1.1 — desyncs it from the rest and surfaces as a confusing build error rather than an obvious version conflict.

## Test plan

- [x] YAML parses and matches the documented schema
- [ ] No new npm version-update PR on the next Dependabot run
- [ ] A security advisory still produces a grouped PR

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkpaW5obf3ezRvTHYaDw2i
